### PR TITLE
Add comprehensive XML documentation to all public types and members

### DIFF
--- a/DMap/App.axaml.cs
+++ b/DMap/App.axaml.cs
@@ -12,13 +12,22 @@ using DMap.Views;
 
 namespace DMap;
 
+/// <summary>
+/// Root Avalonia application class. Initialises the dependency injection container and
+/// wires up the main window with its ViewModel on framework startup.
+/// </summary>
 public partial class App : Application
 {
+    /// <summary>Loads the application XAML resources.</summary>
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);
     }
 
+    /// <summary>
+    /// Builds the DI container, resolves the root ViewModels, and creates the main window
+    /// containing the DM view.
+    /// </summary>
     public override void OnFrameworkInitializationCompleted()
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
@@ -37,6 +46,16 @@ public partial class App : Application
         base.OnFrameworkInitializationCompleted();
     }
 
+    /// <summary>
+    /// Registers all service and ViewModel types with Autofac.
+    /// <list type="bullet">
+    ///   <item><see cref="FogMaskService"/> — transient fog mask (one per DM/player context).</item>
+    ///   <item><see cref="UndoRedoService"/> — singleton undo/redo history shared by the DM.</item>
+    ///   <item><see cref="DmHostService"/> — TCP server for broadcasting to players.</item>
+    ///   <item><see cref="DiscoveryService"/> — UDP broadcast/listen for session discovery.</item>
+    ///   <item><see cref="PlayerClientService"/> — TCP client for connecting to the DM.</item>
+    /// </list>
+    /// </summary>
     static IContainer BuildContainer()
     {
         var builder = new ContainerBuilder();

--- a/DMap/Controls/MapCanvas.cs
+++ b/DMap/Controls/MapCanvas.cs
@@ -11,128 +11,200 @@ using DMap.Models;
 
 namespace DMap.Controls;
 
+/// <summary>
+/// Event arguments for a brush stroke segment, carrying the start and end coordinates
+/// in map pixels and whether the stroke is erasing fog.
+/// </summary>
 public class BrushStrokeEventArgs : EventArgs
 {
+    /// <summary>Start X coordinate in map pixels.</summary>
     public int MapX1 { get; init; }
+
+    /// <summary>Start Y coordinate in map pixels.</summary>
     public int MapY1 { get; init; }
+
+    /// <summary>End X coordinate in map pixels.</summary>
     public int MapX2 { get; init; }
+
+    /// <summary>End Y coordinate in map pixels.</summary>
     public int MapY2 { get; init; }
+
+    /// <summary><see langword="true"/> when the stroke is removing fog; <see langword="false"/> when revealing.</summary>
     public bool IsErasing { get; init; }
 }
 
+/// <summary>
+/// Event arguments for a completed shape drag gesture, carrying the bounding box corners
+/// in map pixels and whether the shape is erasing fog.
+/// </summary>
 public class ShapeStrokeEventArgs : EventArgs
 {
+    /// <summary>First corner X in map pixels.</summary>
     public int MapX1 { get; init; }
+
+    /// <summary>First corner Y in map pixels.</summary>
     public int MapY1 { get; init; }
+
+    /// <summary>Opposite corner X in map pixels.</summary>
     public int MapX2 { get; init; }
+
+    /// <summary>Opposite corner Y in map pixels.</summary>
     public int MapY2 { get; init; }
+
+    /// <summary><see langword="true"/> when the shape is removing fog; <see langword="false"/> when revealing.</summary>
     public bool IsErasing { get; init; }
 }
 
+/// <summary>
+/// Custom Avalonia control that renders a map image, a fog-of-war overlay, and a tool cursor
+/// preview. Handles pointer input to produce brush strokes, shape drags, panning, and zooming.
+/// In player mode (<see cref="IsDmMode"/> = <see langword="false"/>) all editing input is suppressed.
+/// </summary>
 public class MapCanvas : Control
 {
+    /// <summary>Styled property for the map background image.</summary>
     public static readonly StyledProperty<Bitmap?> MapImageProperty =
         AvaloniaProperty.Register<MapCanvas, Bitmap?>(nameof(MapImage));
 
+    /// <summary>Styled property for the fog mask used to build the fog bitmap.</summary>
     public static readonly StyledProperty<FogMask?> FogMaskProperty =
         AvaloniaProperty.Register<MapCanvas, FogMask?>(nameof(FogMask));
 
+    /// <summary>Styled property for the canvas zoom multiplier (default 1.0).</summary>
     public static readonly StyledProperty<double> ZoomLevelProperty =
         AvaloniaProperty.Register<MapCanvas, double>(nameof(ZoomLevel), 1.0);
 
+    /// <summary>Styled property for the horizontal pan offset in screen pixels.</summary>
     public static readonly StyledProperty<double> OffsetXProperty =
         AvaloniaProperty.Register<MapCanvas, double>(nameof(OffsetX));
 
+    /// <summary>Styled property for the vertical pan offset in screen pixels.</summary>
     public static readonly StyledProperty<double> OffsetYProperty =
         AvaloniaProperty.Register<MapCanvas, double>(nameof(OffsetY));
 
+    /// <summary>Styled property that enables DM editing mode (brush/shape input, cursor preview).</summary>
     public static readonly StyledProperty<bool> IsDmModeProperty =
         AvaloniaProperty.Register<MapCanvas, bool>(nameof(IsDmMode));
 
+    /// <summary>Styled property for the fog overlay opacity (0 = transparent, 255 = fully opaque black).</summary>
     public static readonly StyledProperty<byte> FogOpacityProperty =
         AvaloniaProperty.Register<MapCanvas, byte>(nameof(FogOpacity), 255);
 
+    /// <summary>Styled property for the brush diameter preview in screen pixels.</summary>
     public static readonly StyledProperty<int> BrushDiameterProperty =
         AvaloniaProperty.Register<MapCanvas, int>(nameof(BrushDiameter), 50);
 
+    /// <summary>Styled property for the currently active editing tool.</summary>
     public static readonly StyledProperty<ToolType> ActiveToolProperty =
         AvaloniaProperty.Register<MapCanvas, ToolType>(nameof(ActiveTool), ToolType.Brush);
 
+    /// <summary>Styled property for the brush shape used in cursor preview.</summary>
     public static readonly StyledProperty<BrushShape> BrushShapeProperty =
         AvaloniaProperty.Register<MapCanvas, BrushShape>(nameof(BrushShape), BrushShape.Circle);
 
+    /// <summary>Styled property for the shape type used in cursor preview and shape strokes.</summary>
     public static readonly StyledProperty<ShapeType> ShapeTypeProperty =
         AvaloniaProperty.Register<MapCanvas, ShapeType>(nameof(ShapeType), ShapeType.Rectangle);
 
+    /// <summary>The map background image, or <see langword="null"/> when no map is loaded.</summary>
     public Bitmap? MapImage
     {
         get => GetValue(MapImageProperty);
         set => SetValue(MapImageProperty, value);
     }
 
+    /// <summary>The fog mask used to build and update the fog overlay bitmap.</summary>
     public FogMask? FogMask
     {
         get => GetValue(FogMaskProperty);
         set => SetValue(FogMaskProperty, value);
     }
 
+    /// <summary>Zoom multiplier applied via a scale transform before the pan offset.</summary>
     public double ZoomLevel
     {
         get => GetValue(ZoomLevelProperty);
         set => SetValue(ZoomLevelProperty, value);
     }
 
+    /// <summary>Horizontal translation of the canvas in screen pixels.</summary>
     public double OffsetX
     {
         get => GetValue(OffsetXProperty);
         set => SetValue(OffsetXProperty, value);
     }
 
+    /// <summary>Vertical translation of the canvas in screen pixels.</summary>
     public double OffsetY
     {
         get => GetValue(OffsetYProperty);
         set => SetValue(OffsetYProperty, value);
     }
 
+    /// <summary>
+    /// When <see langword="true"/>, the canvas accepts brush/shape input and draws the tool cursor preview.
+    /// When <see langword="false"/> (player mode), only panning and zooming are available.
+    /// </summary>
     public bool IsDmMode
     {
         get => GetValue(IsDmModeProperty);
         set => SetValue(IsDmModeProperty, value);
     }
 
+    /// <summary>
+    /// Opacity of the black fog overlay layer in the range [0, 255].
+    /// Changing this value triggers a full fog bitmap region update and a visual invalidation.
+    /// </summary>
     public byte FogOpacity
     {
         get => GetValue(FogOpacityProperty);
         set => SetValue(FogOpacityProperty, value);
     }
 
+    /// <summary>Brush diameter in map pixels, used to scale the cursor preview outline.</summary>
     public int BrushDiameter
     {
         get => GetValue(BrushDiameterProperty);
         set => SetValue(BrushDiameterProperty, value);
     }
 
+    /// <summary>The currently active editing tool, controlling input behavior and cursor appearance.</summary>
     public ToolType ActiveTool
     {
         get => GetValue(ActiveToolProperty);
         set => SetValue(ActiveToolProperty, value);
     }
 
+    /// <summary>Shape of the brush tip, used to draw the correct cursor outline.</summary>
     public BrushShape BrushShape
     {
         get => GetValue(BrushShapeProperty);
         set => SetValue(BrushShapeProperty, value);
     }
 
+    /// <summary>Geometric shape drawn by the Shape tool.</summary>
     public ShapeType ShapeType
     {
         get => GetValue(ShapeTypeProperty);
         set => SetValue(ShapeTypeProperty, value);
     }
 
+    /// <summary>Raised when the user presses the pointer to begin a brush stroke.</summary>
     public event EventHandler? BrushStrokeStarted;
+
+    /// <summary>Raised when the user releases the pointer to end a brush stroke.</summary>
     public event EventHandler? BrushStrokeEnded;
+
+    /// <summary>
+    /// Raised for each pointer-move event while a brush stroke is in progress,
+    /// carrying the previous and current map coordinates.
+    /// </summary>
     public event EventHandler<BrushStrokeEventArgs>? BrushStrokeApplied;
+
+    /// <summary>
+    /// Raised once when the user releases the pointer after dragging a shape,
+    /// carrying the bounding box corners in map coordinates.
+    /// </summary>
     public event EventHandler<ShapeStrokeEventArgs>? ShapeStrokeApplied;
 
     WriteableBitmap? _fogBitmap;
@@ -155,18 +227,29 @@ public class MapCanvas : Control
             ShapeTypeProperty);
     }
 
+    /// <summary>Initialises the control with clipping and keyboard focus enabled.</summary>
     public MapCanvas()
     {
         ClipToBounds = true;
         Focusable = true;
     }
 
+    /// <summary>
+    /// Updates the fog bitmap for <paramref name="dirtyRect"/> and requests a visual redraw.
+    /// Call this after the fog mask has been modified to sync the bitmap without rebuilding it entirely.
+    /// </summary>
+    /// <param name="dirtyRect">The region of the mask that changed.</param>
     public void InvalidateFogRegion(PixelRect dirtyRect)
     {
         UpdateFogBitmapRegion(dirtyRect);
         InvalidateVisual();
     }
 
+    /// <summary>
+    /// Discards the existing fog bitmap and builds a new <see cref="WriteableBitmap"/> sized to match
+    /// the current <see cref="FogMask"/>. Call this when the mask is replaced entirely (e.g. new map load
+    /// or full fog received from the DM).
+    /// </summary>
     public void RebuildFogBitmap()
     {
         var mask = FogMask;
@@ -185,6 +268,11 @@ public class MapCanvas : Control
         UpdateFogBitmapRegion(new PixelRect(0, 0, mask.Width, mask.Height));
     }
 
+    /// <summary>
+    /// Writes premultiplied BGRA8888 pixels into the fog bitmap for <paramref name="dirtyRect"/>.
+    /// Each pixel is black with an alpha derived from the fog mask value and <see cref="FogOpacity"/>:
+    /// a fully fogged pixel (mask = 0) gets full fog opacity; a fully revealed pixel (mask = 255) is transparent.
+    /// </summary>
     void UpdateFogBitmapRegion(PixelRect dirtyRect)
     {
         var mask = FogMask;
@@ -223,6 +311,11 @@ public class MapCanvas : Control
         }
     }
 
+    /// <summary>
+    /// Renders the black background, the map image, the fog overlay, and (in DM mode) the tool cursor preview.
+    /// The map and fog are drawn inside a scale+translate transform derived from <see cref="ZoomLevel"/>,
+    /// <see cref="OffsetX"/>, and <see cref="OffsetY"/>.
+    /// </summary>
     public override void Render(DrawingContext context)
     {
         base.Render(context);
@@ -255,6 +348,11 @@ public class MapCanvas : Control
             RenderToolOverlay(context, zoom);
     }
 
+    /// <summary>
+    /// Draws the tool cursor outline at the current mouse position. For the Brush tool, draws the
+    /// brush shape outline scaled by the current zoom. For the Shape tool while dragging, draws
+    /// a semi-transparent preview of the shape being placed.
+    /// </summary>
     void RenderToolOverlay(DrawingContext context, double zoom)
     {
         var pen = new Pen(Brushes.White, 1.5);
@@ -318,12 +416,14 @@ public class MapCanvas : Control
         }
     }
 
+    /// <inheritdoc/>
     protected override void OnPointerEntered(PointerEventArgs e)
     {
         base.OnPointerEntered(e);
         UpdateCursor();
     }
 
+    /// <inheritdoc/>
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
     {
         base.OnPropertyChanged(change);
@@ -336,6 +436,11 @@ public class MapCanvas : Control
         }
     }
 
+    /// <summary>
+    /// Updates the cursor based on the current tool and interaction state:
+    /// hidden during painting (to show the brush outline instead), resize-all during panning,
+    /// cross-hair for brush/shape, and default for player mode.
+    /// </summary>
     void UpdateCursor()
     {
         if (!IsDmMode)
@@ -359,6 +464,7 @@ public class MapCanvas : Control
         Cursor = new Cursor(StandardCursorType.Cross);
     }
 
+    /// <inheritdoc/>
     protected override void OnPointerPressed(PointerPressedEventArgs e)
     {
         base.OnPointerPressed(e);
@@ -395,6 +501,11 @@ public class MapCanvas : Control
         }
     }
 
+    /// <summary>
+    /// Begins a paint or shape-drag gesture at <paramref name="position"/>.
+    /// For the Brush tool, fires <see cref="BrushStrokeStarted"/> and the first <see cref="BrushStrokeApplied"/>.
+    /// For the Shape tool, records the drag start point.
+    /// </summary>
     void StartPainting(Point position, bool erase)
     {
         _isErasing = erase;
@@ -413,6 +524,7 @@ public class MapCanvas : Control
         }
     }
 
+    /// <inheritdoc/>
     protected override void OnPointerMoved(PointerEventArgs e)
     {
         base.OnPointerMoved(e);
@@ -439,6 +551,7 @@ public class MapCanvas : Control
             InvalidateVisual();
     }
 
+    /// <inheritdoc/>
     protected override void OnPointerReleased(PointerReleasedEventArgs e)
     {
         base.OnPointerReleased(e);
@@ -459,6 +572,11 @@ public class MapCanvas : Control
         UpdateCursor();
     }
 
+    /// <summary>
+    /// Handles mouse wheel events to zoom the canvas centred on the pointer position,
+    /// adjusting <see cref="OffsetX"/> and <see cref="OffsetY"/> to keep the point under
+    /// the cursor stationary.
+    /// </summary>
     protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
     {
         base.OnPointerWheelChanged(e);
@@ -476,6 +594,10 @@ public class MapCanvas : Control
         e.Handled = true;
     }
 
+    /// <summary>
+    /// Records the current pointer position converted to map coordinates as the starting
+    /// point for the next brush stroke segment.
+    /// </summary>
     void InitBrushMapPos(Point screenPos)
     {
         var zoom = ZoomLevel;
@@ -486,6 +608,10 @@ public class MapCanvas : Control
         _lastBrushMapY = (int)((screenPos.Y - OffsetY) / zoom);
     }
 
+    /// <summary>
+    /// Converts <paramref name="screenTo"/> to map coordinates, fires <see cref="BrushStrokeApplied"/>
+    /// with the segment from the last position to the new position, then updates the last position.
+    /// </summary>
     void RaiseBrushStroke(Point screenTo)
     {
         var zoom = ZoomLevel;
@@ -508,6 +634,10 @@ public class MapCanvas : Control
         _lastBrushMapY = mapY2;
     }
 
+    /// <summary>
+    /// Converts the screen-space drag start and end points to map coordinates and fires
+    /// <see cref="ShapeStrokeApplied"/>.
+    /// </summary>
     void FireShapeStroke(Point screenStart, Point screenEnd)
     {
         var zoom = ZoomLevel;
@@ -526,6 +656,10 @@ public class MapCanvas : Control
         });
     }
 
+    /// <summary>
+    /// Returns a normalized <see cref="Rect"/> whose top-left is at the minimum of both points
+    /// and whose size is the absolute difference.
+    /// </summary>
     static Rect MakeRect(Point a, Point b) =>
         new(Math.Min(a.X, b.X), Math.Min(a.Y, b.Y), Math.Abs(b.X - a.X), Math.Abs(b.Y - a.Y));
 }

--- a/DMap/Converters/BrushShapeIconConverter.cs
+++ b/DMap/Converters/BrushShapeIconConverter.cs
@@ -6,6 +6,10 @@ using DMap.Models;
 
 namespace DMap.Converters;
 
+/// <summary>
+/// Avalonia value converter that maps a <see cref="BrushShape"/> enum value to its SVG icon.
+/// Used in the DM toolbar to display an icon for each brush shape option.
+/// </summary>
 public class BrushShapeIconConverter : EnumSvgConverter<BrushShape>
 {
     static readonly Dictionary<BrushShape, IImage> _icons = new()
@@ -15,5 +19,6 @@ public class BrushShapeIconConverter : EnumSvgConverter<BrushShape>
         [BrushShape.Diamond] = SvgIconLoader.Load("diamond.svg"),
     };
 
+    /// <inheritdoc/>
     protected override IReadOnlyDictionary<BrushShape, IImage> Icons => _icons;
 }

--- a/DMap/Converters/EnumSvgConverter.cs
+++ b/DMap/Converters/EnumSvgConverter.cs
@@ -7,13 +7,26 @@ using Avalonia.Media;
 
 namespace DMap.Converters;
 
+/// <summary>
+/// Base class for Avalonia value converters that map an enum value to a pre-loaded SVG icon.
+/// Subclasses provide a dictionary from enum value to <see cref="IImage"/> via <see cref="Icons"/>.
+/// </summary>
+/// <typeparam name="T">The enum type being converted.</typeparam>
 public abstract class EnumSvgConverter<T> : IValueConverter where T : Enum
 {
+    /// <summary>
+    /// Mapping from enum values to their corresponding SVG images. Must be populated by subclasses.
+    /// </summary>
     protected abstract IReadOnlyDictionary<T, IImage> Icons { get; }
 
+    /// <summary>
+    /// Returns the <see cref="IImage"/> for the given enum <paramref name="value"/>,
+    /// or <see langword="null"/> if the value is not in <see cref="Icons"/>.
+    /// </summary>
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         => value is T key && Icons.TryGetValue(key, out var icon) ? icon : null;
 
+    /// <summary>Not supported. Throws <see cref="NotSupportedException"/>.</summary>
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         => throw new NotSupportedException();
 }

--- a/DMap/Converters/ShapeTypeIconConverter.cs
+++ b/DMap/Converters/ShapeTypeIconConverter.cs
@@ -6,6 +6,10 @@ using DMap.Models;
 
 namespace DMap.Converters;
 
+/// <summary>
+/// Avalonia value converter that maps a <see cref="ShapeType"/> enum value to its SVG icon.
+/// Used in the DM toolbar to display an icon for each shape tool option.
+/// </summary>
 public class ShapeTypeIconConverter : EnumSvgConverter<ShapeType>
 {
     static readonly Dictionary<ShapeType, IImage> _icons = new()
@@ -16,5 +20,6 @@ public class ShapeTypeIconConverter : EnumSvgConverter<ShapeType>
         [ShapeType.Circle] = SvgIconLoader.Load("circle.svg"),
     };
 
+    /// <inheritdoc/>
     protected override IReadOnlyDictionary<ShapeType, IImage> Icons => _icons;
 }

--- a/DMap/Converters/SvgIconLoader.cs
+++ b/DMap/Converters/SvgIconLoader.cs
@@ -5,10 +5,18 @@ using Avalonia.Svg.Skia;
 
 namespace DMap.Converters;
 
+/// <summary>
+/// Loads SVG icons from the embedded application assets at <c>avares://DMap/Assets/Icons/</c>.
+/// </summary>
 internal static class SvgIconLoader
 {
     static readonly Uri _iconBaseUri = new("avares://DMap/Assets/Icons/");
 
+    /// <summary>
+    /// Loads the SVG file with the given <paramref name="fileName"/> from the icon assets directory
+    /// and returns it as an <see cref="IImage"/> usable in Avalonia controls.
+    /// </summary>
+    /// <param name="fileName">File name relative to the icon assets directory (e.g. "circle.svg").</param>
     public static IImage Load(string fileName)
     {
         var uri = new Uri(_iconBaseUri, fileName);

--- a/DMap/Converters/ToolTypeIconConverter.cs
+++ b/DMap/Converters/ToolTypeIconConverter.cs
@@ -6,6 +6,10 @@ using DMap.Models;
 
 namespace DMap.Converters;
 
+/// <summary>
+/// Avalonia value converter that maps a <see cref="ToolType"/> enum value to its SVG icon.
+/// Used in the DM toolbar to display an icon for each editing tool.
+/// </summary>
 public class ToolTypeIconConverter : EnumSvgConverter<ToolType>
 {
     static readonly Dictionary<ToolType, IImage> _icons = new()
@@ -15,5 +19,6 @@ public class ToolTypeIconConverter : EnumSvgConverter<ToolType>
         [ToolType.Pan] = SvgIconLoader.Load("hand.svg"),
     };
 
+    /// <inheritdoc/>
     protected override IReadOnlyDictionary<ToolType, IImage> Icons => _icons;
 }

--- a/DMap/Models/BrushSettings.cs
+++ b/DMap/Models/BrushSettings.cs
@@ -1,3 +1,17 @@
 namespace DMap.Models;
 
+/// <summary>
+/// Immutable configuration for a single brush stroke operation.
+/// </summary>
+/// <param name="Diameter">Diameter of the brush in map pixels.</param>
+/// <param name="Softness">
+/// Edge feathering in the range [0, 1]. 0 produces a hard edge; 1 makes the entire
+/// brush area a gradient from the centre outward.
+/// </param>
+/// <param name="Opacity">
+/// Maximum alpha applied by one stroke in the range [0, 1]. Defaults to 1 (fully opaque).
+/// </param>
+/// <param name="Erase">
+/// When <see langword="true"/> the stroke removes fog; when <see langword="false"/> it adds fog.
+/// </param>
 public sealed record BrushSettings(int Diameter, float Softness, float Opacity = 1.0f, bool Erase = false);

--- a/DMap/Models/BrushShape.cs
+++ b/DMap/Models/BrushShape.cs
@@ -1,8 +1,16 @@
 namespace DMap.Models;
 
+/// <summary>
+/// The shape of the brush tip used when painting fog of war.
+/// </summary>
 public enum BrushShape
 {
+    /// <summary>Circular brush tip, using Euclidean distance.</summary>
     Circle,
+
+    /// <summary>Square brush tip, using Chebyshev (infinity-norm) distance.</summary>
     Square,
+
+    /// <summary>Diamond brush tip, using Manhattan (L1-norm) distance.</summary>
     Diamond,
 }

--- a/DMap/Models/FogMask.cs
+++ b/DMap/Models/FogMask.cs
@@ -2,12 +2,30 @@ using System;
 
 namespace DMap.Models;
 
+/// <summary>
+/// A 2-D grayscale mask that tracks the fog-of-war state for every map pixel.
+/// Each byte represents the revealed amount for one pixel: 0 = fully fogged,
+/// 255 = fully revealed. Values in between produce a partial reveal.
+/// </summary>
 public sealed class FogMask
 {
+    /// <summary>Width of the mask in pixels, matching the loaded map image width.</summary>
     public int Width { get; }
+
+    /// <summary>Height of the mask in pixels, matching the loaded map image height.</summary>
     public int Height { get; }
+
+    /// <summary>
+    /// Raw pixel data stored in row-major order (index = y * Width + x).
+    /// Each byte is the reveal value for one pixel.
+    /// </summary>
     public byte[] Data { get; }
 
+    /// <summary>
+    /// Creates a new mask of the given dimensions with all pixels set to 0 (fully fogged).
+    /// </summary>
+    /// <param name="width">Width in pixels.</param>
+    /// <param name="height">Height in pixels.</param>
     public FogMask(int width, int height)
     {
         Width = width;
@@ -15,6 +33,13 @@ public sealed class FogMask
         Data = new byte[width * height];
     }
 
+    /// <summary>
+    /// Creates a mask backed by an existing data array.
+    /// </summary>
+    /// <param name="width">Width in pixels.</param>
+    /// <param name="height">Height in pixels.</param>
+    /// <param name="data">Pixel data; must have exactly <paramref name="width"/> * <paramref name="height"/> bytes.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="data"/> length does not equal width * height.</exception>
     public FogMask(int width, int height, byte[] data)
     {
         if (data.Length != width * height)
@@ -25,12 +50,19 @@ public sealed class FogMask
         Data = data;
     }
 
+    /// <summary>
+    /// Gets or sets the reveal value for the pixel at column <paramref name="x"/>, row <paramref name="y"/>.
+    /// </summary>
     public byte this[int x, int y]
     {
         get => Data[y * Width + x];
         set => Data[y * Width + x] = value;
     }
 
+    /// <summary>
+    /// Creates a deep copy of this mask with independent pixel data.
+    /// </summary>
+    /// <returns>A new <see cref="FogMask"/> with identical dimensions and pixel values.</returns>
     public FogMask Clone()
     {
         var copy = new byte[Data.Length];

--- a/DMap/Models/IFogCommand.cs
+++ b/DMap/Models/IFogCommand.cs
@@ -2,6 +2,11 @@ using Avalonia;
 
 namespace DMap.Models;
 
+/// <summary>
+/// Represents a reversible fog-of-war edit that can be undone and redone.
+/// Implementations capture pixel state before and after an operation so the
+/// affected region can be restored in either direction.
+/// </summary>
 public interface IFogCommand
 {
     /// <summary>
@@ -10,6 +15,15 @@ public interface IFogCommand
     /// </summary>
     PixelRect DirtyRect { get; }
 
+    /// <summary>
+    /// Restores the fog mask to the state it was in before this command was applied.
+    /// </summary>
+    /// <param name="mask">The fog mask to write the before-state into.</param>
     void Undo(FogMask mask);
+
+    /// <summary>
+    /// Re-applies this command to the fog mask, restoring the after-state.
+    /// </summary>
+    /// <param name="mask">The fog mask to write the after-state into.</param>
     void Redo(FogMask mask);
 }

--- a/DMap/Models/MapSession.cs
+++ b/DMap/Models/MapSession.cs
@@ -2,4 +2,12 @@ using System;
 
 namespace DMap.Models;
 
+/// <summary>
+/// Identifies an active DM hosting session together with the dimensions of its map.
+/// Transmitted to player clients during the initial handshake so they can allocate
+/// a fog mask of the correct size.
+/// </summary>
+/// <param name="SessionId">Unique identifier for this session, generated when a map is loaded.</param>
+/// <param name="MapWidth">Width of the map image in pixels.</param>
+/// <param name="MapHeight">Height of the map image in pixels.</param>
 public sealed record MapSession(Guid SessionId, int MapWidth, int MapHeight);

--- a/DMap/Models/ShapeType.cs
+++ b/DMap/Models/ShapeType.cs
@@ -1,9 +1,19 @@
 namespace DMap.Models;
 
+/// <summary>
+/// The geometric shape drawn by the Shape tool.
+/// </summary>
 public enum ShapeType
 {
+    /// <summary>Axis-aligned rectangle whose width and height may differ.</summary>
     Rectangle,
+
+    /// <summary>Axis-aligned square (width == height, constrained during drag).</summary>
     Square,
+
+    /// <summary>Ellipse whose horizontal and vertical radii may differ.</summary>
     Ellipse,
+
+    /// <summary>Circle whose horizontal and vertical radii are equal (constrained during drag).</summary>
     Circle,
 }

--- a/DMap/Models/ToolType.cs
+++ b/DMap/Models/ToolType.cs
@@ -1,8 +1,16 @@
 namespace DMap.Models;
 
+/// <summary>
+/// The active editing tool on the DM canvas.
+/// </summary>
 public enum ToolType
 {
+    /// <summary>Free-hand brush that paints or erases fog along a stroke.</summary>
     Brush,
+
+    /// <summary>Shape tool that draws a filled rectangle or ellipse in one drag gesture.</summary>
     Shape,
+
+    /// <summary>Pan tool that scrolls the map viewport without modifying the fog.</summary>
     Pan,
 }

--- a/DMap/Program.cs
+++ b/DMap/Program.cs
@@ -6,16 +6,26 @@ using ReactiveUI.Avalonia;
 
 namespace DMap;
 
+/// <summary>
+/// Application entry point. Must run on an STA thread (required by some platform UI frameworks).
+/// </summary>
 sealed class Program
 {
     // Initialization code. Don't use any Avalonia, third-party APIs or any
     // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
     // yet and stuff might break.
+    /// <summary>
+    /// Application entry point. Builds the Avalonia app and starts the classic desktop lifetime.
+    /// </summary>
     [STAThread]
     public static void Main(string[] args) => BuildAvaloniaApp()
         .StartWithClassicDesktopLifetime(args);
 
     // Avalonia configuration, don't remove; also used by visual designer.
+    /// <summary>
+    /// Configures the Avalonia <see cref="AppBuilder"/> with platform detection, the Inter font,
+    /// trace logging, and ReactiveUI integration.
+    /// </summary>
     public static AppBuilder BuildAvaloniaApp()
         => AppBuilder.Configure<App>()
             .UsePlatformDetect()

--- a/DMap/Services/Brushes/BrushHelper.cs
+++ b/DMap/Services/Brushes/BrushHelper.cs
@@ -2,8 +2,32 @@ using DMap.Models;
 
 namespace DMap.Services.Brushes;
 
+/// <summary>
+/// Shared pixel-level blending logic used by all brush implementations.
+/// </summary>
 internal static class BrushHelper
 {
+    /// <summary>
+    /// Writes the reveal value for a single fog pixel, respecting coverage, opacity, and erase mode.
+    /// The operation only moves the pixel in the target direction (reveal or erase); it never
+    /// reduces the reveal level when painting or increases it when erasing.
+    /// </summary>
+    /// <param name="mask">The fog mask to update.</param>
+    /// <param name="px">X coordinate of the pixel.</param>
+    /// <param name="py">Y coordinate of the pixel.</param>
+    /// <param name="coverage">
+    /// Geometric coverage for this pixel in the range [0, 1]. Values less than 1 are produced
+    /// by the softness gradient at brush edges.
+    /// </param>
+    /// <param name="erase">
+    /// <see langword="true"/> to remove fog (reduce reveal value);
+    /// <see langword="false"/> to add fog reveal (increase reveal value).
+    /// </param>
+    /// <param name="snapshotValue">
+    /// The pixel's reveal value at the moment the stroke began, used as the base for computing
+    /// the target alpha so repeated passes do not stack beyond one application of opacity.
+    /// </param>
+    /// <param name="opacity">Maximum stroke opacity in the range [0, 1].</param>
     internal static void ApplyPixel(FogMask mask, int px, int py, double coverage, bool erase, byte snapshotValue, float opacity)
     {
         var effectiveCoverage = coverage * opacity;

--- a/DMap/Services/Brushes/CircleBrush.cs
+++ b/DMap/Services/Brushes/CircleBrush.cs
@@ -6,10 +6,16 @@ using DMap.Models;
 
 namespace DMap.Services.Brushes;
 
+/// <summary>
+/// Brush tip that produces a circular stroke by measuring each pixel's Euclidean distance
+/// to the nearest point on the stroke segment. Softness feathers the outer annulus of the brush.
+/// </summary>
 public sealed class CircleBrush : IBrush
 {
+    /// <inheritdoc/>
     public string Name => "Circle";
 
+    /// <inheritdoc/>
     public PixelRect Apply(FogMask mask, int x1, int y1, int x2, int y2, BrushSettings settings, byte[]? snapshot = null)
     {
         var radius = settings.Diameter / 2.0;
@@ -48,6 +54,10 @@ public sealed class CircleBrush : IBrush
         return new PixelRect(minX, minY, maxX - minX + 1, maxY - minY + 1);
     }
 
+    /// <summary>
+    /// Returns the Euclidean distance from point (<paramref name="px"/>, <paramref name="py"/>) to
+    /// the segment from (x1, y1) with direction vector (dx, dy) and squared length <paramref name="lenSq"/>.
+    /// </summary>
     static double DistToSegment(int px, int py, int x1, int y1, double dx, double dy, double lenSq)
     {
         if (lenSq < 1e-10)

--- a/DMap/Services/Brushes/DiamondBrush.cs
+++ b/DMap/Services/Brushes/DiamondBrush.cs
@@ -6,10 +6,16 @@ using DMap.Models;
 
 namespace DMap.Services.Brushes;
 
+/// <summary>
+/// Brush tip that produces a diamond-shaped stroke by measuring each pixel's Manhattan (L1-norm)
+/// distance to the nearest point on the stroke segment. Softness feathers the outer band of the brush.
+/// </summary>
 public sealed class DiamondBrush : IBrush
 {
+    /// <inheritdoc/>
     public string Name => "Diamond";
 
+    /// <inheritdoc/>
     public PixelRect Apply(FogMask mask, int x1, int y1, int x2, int y2, BrushSettings settings, byte[]? snapshot = null)
     {
         var radius = settings.Diameter / 2.0;
@@ -49,6 +55,11 @@ public sealed class DiamondBrush : IBrush
 
     // Minimises |rx - t*dx| + |ry - t*dy| over t ∈ [0,1].
     // The piecewise-linear minimum is always at an endpoint or a kink of one of the absolute-value terms.
+    /// <summary>
+    /// Returns the Manhattan (L1-norm) distance from point (<paramref name="px"/>, <paramref name="py"/>)
+    /// to the segment starting at (ax, ay) with direction (dx, dy).
+    /// The minimum is found analytically by evaluating the piecewise-linear objective at all critical t values.
+    /// </summary>
     static double ManhattanDistToSegment(int px, int py, int ax, int ay, double dx, double dy)
     {
         var rx = px - ax;

--- a/DMap/Services/Brushes/IBrush.cs
+++ b/DMap/Services/Brushes/IBrush.cs
@@ -4,8 +4,30 @@ using DMap.Models;
 
 namespace DMap.Services.Brushes;
 
+/// <summary>
+/// Defines a brush tip that can paint or erase fog along a line segment between two map coordinates.
+/// Each implementation uses a different distance metric to produce a distinct brush shape.
+/// </summary>
 public interface IBrush
 {
+    /// <summary>Display name of the brush (e.g. "Circle", "Square", "Diamond").</summary>
     string Name { get; }
+
+    /// <summary>
+    /// Applies the brush stroke from map point (<paramref name="x1"/>, <paramref name="y1"/>) to
+    /// (<paramref name="x2"/>, <paramref name="y2"/>) and updates <paramref name="mask"/> in place.
+    /// </summary>
+    /// <param name="mask">The fog mask to modify.</param>
+    /// <param name="x1">Start X coordinate in map pixels.</param>
+    /// <param name="y1">Start Y coordinate in map pixels.</param>
+    /// <param name="x2">End X coordinate in map pixels.</param>
+    /// <param name="y2">End Y coordinate in map pixels.</param>
+    /// <param name="settings">Brush diameter, softness, opacity, and erase mode.</param>
+    /// <param name="snapshot">
+    /// Optional read-only snapshot of the mask taken at the start of the stroke. When provided,
+    /// coverage is computed relative to the snapshot so repeated passes over the same area do not
+    /// accumulate beyond a single application of the opacity.
+    /// </param>
+    /// <returns>The bounding rectangle of all pixels that were potentially modified.</returns>
     PixelRect Apply(FogMask mask, int x1, int y1, int x2, int y2, BrushSettings settings, byte[]? snapshot = null);
 }

--- a/DMap/Services/Brushes/SquareBrush.cs
+++ b/DMap/Services/Brushes/SquareBrush.cs
@@ -6,10 +6,16 @@ using DMap.Models;
 
 namespace DMap.Services.Brushes;
 
+/// <summary>
+/// Brush tip that produces a square stroke by measuring each pixel's Chebyshev (infinity-norm)
+/// distance to the nearest point on the stroke segment. Softness feathers the outer band of the brush.
+/// </summary>
 public sealed class SquareBrush : IBrush
 {
+    /// <inheritdoc/>
     public string Name => "Square";
 
+    /// <inheritdoc/>
     public PixelRect Apply(FogMask mask, int x1, int y1, int x2, int y2, BrushSettings settings, byte[]? snapshot = null)
     {
         var radius = settings.Diameter / 2.0;
@@ -49,6 +55,11 @@ public sealed class SquareBrush : IBrush
 
     // Minimises max(|rx - t*dx|, |ry - t*dy|) over t ∈ [0,1].
     // Critical points: endpoints, where the two terms are equal, and kinks of each term.
+    /// <summary>
+    /// Returns the Chebyshev (infinity-norm) distance from point (<paramref name="px"/>, <paramref name="py"/>)
+    /// to the segment starting at (ax, ay) with direction (dx, dy).
+    /// The minimum is found analytically by evaluating the piecewise-linear objective at all critical t values.
+    /// </summary>
     static double ChebyshevDistToSegment(int px, int py, int ax, int ay, double dx, double dy)
     {
         var rx = px - ax;

--- a/DMap/Services/Fog/FogMaskService.cs
+++ b/DMap/Services/Fog/FogMaskService.cs
@@ -9,17 +9,28 @@ using DMap.Services.Networking;
 
 namespace DMap.Services.Fog;
 
+/// <summary>
+/// Default implementation of <see cref="IFogMaskService"/>. Tracks a per-stroke snapshot
+/// for opacity-consistent brush painting and accumulates a dirty rectangle so that only
+/// the changed region needs to be re-rendered or transmitted.
+/// </summary>
 public sealed class FogMaskService : IFogMaskService
 {
     const string MaskNotInitialized = "Fog mask not initialized.";
 
+    /// <inheritdoc/>
     public FogMask? Mask { get; private set; }
 
+    /// <summary>Pixel snapshot captured at the start of the current stroke, or <see langword="null"/> when no stroke is in progress.</summary>
     byte[]? _snapshot;
+
+    /// <summary>Union of all dirty rectangles produced during the current stroke, or <see langword="null"/> when no pixels have been touched yet.</summary>
     PixelRect? _strokeDirtyRect;
 
+    /// <inheritdoc/>
     public event EventHandler<PixelRect>? MaskChanged;
 
+    /// <inheritdoc/>
     public void Initialize(int width, int height)
     {
         Mask = new FogMask(width, height);
@@ -27,6 +38,7 @@ public sealed class FogMaskService : IFogMaskService
         _strokeDirtyRect = null;
     }
 
+    /// <inheritdoc/>
     public void BeginStroke()
     {
         if (Mask is null)
@@ -37,6 +49,7 @@ public sealed class FogMaskService : IFogMaskService
         _strokeDirtyRect = null;
     }
 
+    /// <inheritdoc/>
     public IFogCommand? EndStroke()
     {
         var snapshot = _snapshot;
@@ -52,6 +65,7 @@ public sealed class FogMaskService : IFogMaskService
         return new FogDeltaCommand(strokeRect.Value, before, after);
     }
 
+    /// <inheritdoc/>
     public PixelRect ApplyBrush(IBrush brush, int x1, int y1, int x2, int y2, BrushSettings settings)
     {
         if (Mask is null)
@@ -66,6 +80,7 @@ public sealed class FogMaskService : IFogMaskService
         return dirtyRect;
     }
 
+    /// <inheritdoc/>
     public PixelRect ApplyRectangle(int x1, int y1, int x2, int y2, float softness, float opacity, bool erase = false)
     {
         if (Mask is null)
@@ -93,6 +108,7 @@ public sealed class FogMaskService : IFogMaskService
         return dirtyRect;
     }
 
+    /// <inheritdoc/>
     public PixelRect ApplyEllipse(int x1, int y1, int x2, int y2, float softness, float opacity, bool erase = false)
     {
         if (Mask is null)
@@ -137,6 +153,7 @@ public sealed class FogMaskService : IFogMaskService
         return dirtyRect;
     }
 
+    /// <inheritdoc/>
     public void RevealAll()
     {
         if (Mask is null)
@@ -146,6 +163,7 @@ public sealed class FogMaskService : IFogMaskService
         MaskChanged?.Invoke(this, new PixelRect(0, 0, Mask.Width, Mask.Height));
     }
 
+    /// <inheritdoc/>
     public void RefogAll()
     {
         if (Mask is null)
@@ -155,12 +173,14 @@ public sealed class FogMaskService : IFogMaskService
         MaskChanged?.Invoke(this, new PixelRect(0, 0, Mask.Width, Mask.Height));
     }
 
+    /// <inheritdoc/>
     public void Replace(FogMask mask)
     {
         Mask = mask;
         MaskChanged?.Invoke(this, new PixelRect(0, 0, mask.Width, mask.Height));
     }
 
+    /// <inheritdoc/>
     public void ApplyDelta(FogDelta delta)
     {
         if (Mask is null)
@@ -184,6 +204,7 @@ public sealed class FogMaskService : IFogMaskService
         MaskChanged?.Invoke(this, new PixelRect(delta.X, delta.Y, delta.Width, delta.Height));
     }
 
+    /// <summary>Returns the smallest rectangle that contains both <paramref name="a"/> and <paramref name="b"/>.</summary>
     static PixelRect UnionRects(PixelRect a, PixelRect b)
     {
         var x = Math.Min(a.X, b.X);
@@ -193,6 +214,11 @@ public sealed class FogMaskService : IFogMaskService
         return new PixelRect(x, y, right - x, bottom - y);
     }
 
+    /// <summary>
+    /// Returns the coverage value in [0, 1] for a pixel at (<paramref name="x"/>, <paramref name="y"/>)
+    /// inside a rectangle, based on its distance from the nearest edge and the feather width.
+    /// Pixels closer to the edge than <paramref name="feather"/> receive a proportionally reduced coverage.
+    /// </summary>
     static double RectCoverage(int x, int y, int minX, int minY, int maxX, int maxY, float feather)
     {
         if (feather <= 0)

--- a/DMap/Services/Fog/IFogMaskService.cs
+++ b/DMap/Services/Fog/IFogMaskService.cs
@@ -8,29 +8,94 @@ using DMap.Services.Networking;
 
 namespace DMap.Services.Fog;
 
+/// <summary>
+/// Manages the fog-of-war mask for the current map session: initialization, painting,
+/// shape fills, undo/redo snapshots, and applying network-received deltas.
+/// </summary>
 public interface IFogMaskService
 {
+    /// <summary>
+    /// The current fog mask, or <see langword="null"/> when no map has been loaded yet.
+    /// </summary>
     FogMask? Mask { get; }
 
+    /// <summary>
+    /// Raised after any modification to the mask. The event argument is the bounding
+    /// rectangle of the changed region, which can be used to limit bitmap updates and redraws.
+    /// </summary>
     event EventHandler<PixelRect>? MaskChanged;
 
+    /// <summary>
+    /// Allocates a new fully-fogged mask matching the given dimensions.
+    /// Resets any in-progress stroke snapshot.
+    /// </summary>
+    /// <param name="width">Map width in pixels.</param>
+    /// <param name="height">Map height in pixels.</param>
     void Initialize(int width, int height);
 
+    /// <summary>
+    /// Captures a snapshot of the current mask so that subsequent brush applications
+    /// during this stroke are computed relative to the stroke start state, preventing
+    /// opacity from accumulating on repeated passes over the same area.
+    /// </summary>
     void BeginStroke();
 
+    /// <summary>
+    /// Finalises the current stroke and returns an <see cref="IFogCommand"/> that can
+    /// be pushed onto the undo stack. Returns <see langword="null"/> if no pixels changed.
+    /// </summary>
     IFogCommand? EndStroke();
 
+    /// <summary>
+    /// Applies a brush stroke from (<paramref name="x1"/>, <paramref name="y1"/>) to
+    /// (<paramref name="x2"/>, <paramref name="y2"/>) using the provided brush and settings,
+    /// accumulating the dirty region into the current stroke rectangle.
+    /// </summary>
+    /// <returns>Bounding rectangle of pixels that were modified.</returns>
     PixelRect ApplyBrush(IBrush brush, int x1, int y1, int x2, int y2, BrushSettings settings);
 
+    /// <summary>
+    /// Fills (or erases) a rectangular region of the mask with optional edge feathering.
+    /// </summary>
+    /// <param name="x1">First corner X in map pixels.</param>
+    /// <param name="y1">First corner Y in map pixels.</param>
+    /// <param name="x2">Opposite corner X in map pixels.</param>
+    /// <param name="y2">Opposite corner Y in map pixels.</param>
+    /// <param name="softness">Edge feathering in [0, 1]; 0 = hard edge.</param>
+    /// <param name="opacity">Maximum alpha to apply in [0, 1].</param>
+    /// <param name="erase">When <see langword="true"/>, removes fog instead of adding it.</param>
+    /// <returns>Bounding rectangle of pixels that were modified.</returns>
     PixelRect ApplyRectangle(int x1, int y1, int x2, int y2, float softness, float opacity, bool erase = false);
 
+    /// <summary>
+    /// Fills (or erases) an elliptical region of the mask with optional edge feathering.
+    /// </summary>
+    /// <param name="x1">First corner X of the bounding box in map pixels.</param>
+    /// <param name="y1">First corner Y of the bounding box in map pixels.</param>
+    /// <param name="x2">Opposite corner X of the bounding box in map pixels.</param>
+    /// <param name="y2">Opposite corner Y of the bounding box in map pixels.</param>
+    /// <param name="softness">Edge feathering in [0, 1]; 0 = hard edge.</param>
+    /// <param name="opacity">Maximum alpha to apply in [0, 1].</param>
+    /// <param name="erase">When <see langword="true"/>, removes fog instead of adding it.</param>
+    /// <returns>Bounding rectangle of pixels that were modified.</returns>
     PixelRect ApplyEllipse(int x1, int y1, int x2, int y2, float softness, float opacity, bool erase = false);
 
+    /// <summary>Sets every pixel in the mask to 255 (fully revealed).</summary>
     void RevealAll();
 
+    /// <summary>Sets every pixel in the mask to 0 (fully fogged).</summary>
     void RefogAll();
 
+    /// <summary>
+    /// Replaces the current mask entirely with <paramref name="mask"/> and raises
+    /// <see cref="MaskChanged"/> for the full map rectangle.
+    /// </summary>
     void Replace(FogMask mask);
 
+    /// <summary>
+    /// Merges a network-received fog delta into the mask using a max-blend: only pixels
+    /// that are more revealed in the delta override the local value, so fog can never be
+    /// re-added via a network update.
+    /// </summary>
     void ApplyDelta(FogDelta delta);
 }

--- a/DMap/Services/History/FogDeltaCommand.cs
+++ b/DMap/Services/History/FogDeltaCommand.cs
@@ -6,13 +6,25 @@ using DMap.Models;
 
 namespace DMap.Services.History;
 
+/// <summary>
+/// An <see cref="IFogCommand"/> that stores a rectangular snapshot of the fog mask
+/// before and after an operation so the region can be restored in either direction.
+/// </summary>
 public sealed class FogDeltaCommand : IFogCommand
 {
     readonly byte[] _before;
     readonly byte[] _after;
 
+    /// <inheritdoc/>
     public PixelRect DirtyRect { get; }
 
+    /// <summary>
+    /// Creates a command that can flip the pixels inside <paramref name="dirtyRect"/>
+    /// between two captured states.
+    /// </summary>
+    /// <param name="dirtyRect">The region covered by the before/after data.</param>
+    /// <param name="before">Pixel values captured before the operation.</param>
+    /// <param name="after">Pixel values captured after the operation.</param>
     public FogDeltaCommand(PixelRect dirtyRect, byte[] before, byte[] after)
     {
         DirtyRect = dirtyRect;
@@ -20,9 +32,16 @@ public sealed class FogDeltaCommand : IFogCommand
         _after = after;
     }
 
+    /// <inheritdoc/>
     public void Undo(FogMask mask) => ApplyRegion(mask, _before);
+
+    /// <inheritdoc/>
     public void Redo(FogMask mask) => ApplyRegion(mask, _after);
 
+    /// <summary>
+    /// Copies <paramref name="data"/> (a row-major sub-image of width <see cref="PixelRect.Width"/>)
+    /// into the corresponding rows of <paramref name="mask"/>.
+    /// </summary>
     void ApplyRegion(FogMask mask, byte[] data)
     {
         for (var dy = 0; dy < DirtyRect.Height; dy++)
@@ -31,6 +50,12 @@ public sealed class FogDeltaCommand : IFogCommand
                 DirtyRect.Width);
     }
 
+    /// <summary>
+    /// Extracts the pixel values inside <paramref name="region"/> from a live fog mask.
+    /// </summary>
+    /// <param name="mask">The mask to read from.</param>
+    /// <param name="region">The rectangle to capture.</param>
+    /// <returns>A row-major byte array of size region.Width * region.Height.</returns>
     public static byte[] CaptureFromMask(FogMask mask, PixelRect region)
     {
         var data = new byte[region.Width * region.Height];
@@ -40,6 +65,15 @@ public sealed class FogDeltaCommand : IFogCommand
         return data;
     }
 
+    /// <summary>
+    /// Extracts the pixel values inside <paramref name="region"/> from a raw byte array
+    /// that uses the same row-major layout as a fog mask with the given width.
+    /// Used to capture the before-state from a pre-stroke snapshot.
+    /// </summary>
+    /// <param name="rawData">Raw pixel data with layout identical to <see cref="FogMask.Data"/>.</param>
+    /// <param name="maskWidth">Width of the mask the raw data belongs to.</param>
+    /// <param name="region">The rectangle to capture.</param>
+    /// <returns>A row-major byte array of size region.Width * region.Height.</returns>
     public static byte[] CaptureFromRaw(byte[] rawData, int maskWidth, PixelRect region)
     {
         var data = new byte[region.Width * region.Height];

--- a/DMap/Services/History/IUndoRedoService.cs
+++ b/DMap/Services/History/IUndoRedoService.cs
@@ -4,15 +4,46 @@ using DMap.Models;
 
 namespace DMap.Services.History;
 
+/// <summary>
+/// Manages a bounded undo/redo history of fog-of-war commands.
+/// Pushing a new command always clears the redo stack.
+/// </summary>
 public interface IUndoRedoService
 {
+    /// <summary>
+    /// <see langword="true"/> when there is at least one command available to undo.
+    /// </summary>
     bool CanUndo { get; }
+
+    /// <summary>
+    /// <see langword="true"/> when there is at least one command available to redo.
+    /// </summary>
     bool CanRedo { get; }
 
+    /// <summary>
+    /// Raised whenever <see cref="CanUndo"/> or <see cref="CanRedo"/> changes,
+    /// allowing UI bindings to refresh command availability.
+    /// </summary>
     event EventHandler? StateChanged;
 
+    /// <summary>
+    /// Adds <paramref name="command"/> to the undo stack and clears the redo stack.
+    /// If the history limit is reached the oldest entry is discarded.
+    /// </summary>
     void Push(IFogCommand command);
+
+    /// <summary>
+    /// Removes and returns the most recent command from the undo stack, moving it to
+    /// the redo stack. Returns <see langword="null"/> when the undo stack is empty.
+    /// </summary>
     IFogCommand? TakeUndo();
+
+    /// <summary>
+    /// Removes and returns the most recently undone command from the redo stack, moving
+    /// it back onto the undo stack. Returns <see langword="null"/> when the redo stack is empty.
+    /// </summary>
     IFogCommand? TakeRedo();
+
+    /// <summary>Empties both the undo and redo stacks.</summary>
     void Clear();
 }

--- a/DMap/Services/History/UndoRedoService.cs
+++ b/DMap/Services/History/UndoRedoService.cs
@@ -5,18 +5,29 @@ using DMap.Models;
 
 namespace DMap.Services.History;
 
+/// <summary>
+/// Default implementation of <see cref="IUndoRedoService"/>. Stores up to
+/// <c>MaxHistory</c> commands in a linked-list undo stack and a stack-based redo
+/// buffer. Oldest entries are evicted when the undo stack overflows.
+/// </summary>
 public sealed class UndoRedoService : IUndoRedoService
 {
+    /// <summary>Maximum number of commands retained in the undo history.</summary>
     const int MaxHistory = 10;
 
     readonly LinkedList<IFogCommand> _undoStack = new();
     readonly Stack<IFogCommand> _redoStack = new();
 
+    /// <inheritdoc/>
     public bool CanUndo => _undoStack.Count > 0;
+
+    /// <inheritdoc/>
     public bool CanRedo => _redoStack.Count > 0;
 
+    /// <inheritdoc/>
     public event EventHandler? StateChanged;
 
+    /// <inheritdoc/>
     public void Push(IFogCommand command)
     {
         _undoStack.AddLast(command);
@@ -26,6 +37,7 @@ public sealed class UndoRedoService : IUndoRedoService
         StateChanged?.Invoke(this, EventArgs.Empty);
     }
 
+    /// <inheritdoc/>
     public IFogCommand? TakeUndo()
     {
         if (_undoStack.Count == 0)
@@ -38,6 +50,7 @@ public sealed class UndoRedoService : IUndoRedoService
         return command;
     }
 
+    /// <inheritdoc/>
     public IFogCommand? TakeRedo()
     {
         if (_redoStack.Count == 0)
@@ -49,6 +62,7 @@ public sealed class UndoRedoService : IUndoRedoService
         return command;
     }
 
+    /// <inheritdoc/>
     public void Clear()
     {
         _undoStack.Clear();

--- a/DMap/Services/Networking/DiscoveryService.cs
+++ b/DMap/Services/Networking/DiscoveryService.cs
@@ -9,16 +9,25 @@ using DMap.Models;
 
 namespace DMap.Services.Networking;
 
+/// <summary>
+/// Default implementation of <see cref="IDiscoveryService"/> using UDP broadcast on a fixed port.
+/// Packet format: "DMAP" magic (4 bytes) | SessionId (16 bytes) | TCP port (4 bytes) |
+/// name byte length (4 bytes) | UTF-8 machine name.
+/// </summary>
 public sealed class DiscoveryService : IDiscoveryService
 {
+    /// <summary>UDP port used for both sending and receiving discovery broadcast packets.</summary>
     const int DiscoveryPort = 19876;
+
     static readonly byte[] _magic = "DMAP"u8.ToArray();
 
     UdpClient? _udpClient;
     CancellationTokenSource? _cts;
 
+    /// <inheritdoc/>
     public event EventHandler<DiscoveredDm>? DmDiscovered;
 
+    /// <inheritdoc/>
     public async Task StartBroadcastingAsync(MapSession session, int tcpPort, CancellationToken ct)
     {
         _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
@@ -51,6 +60,7 @@ public sealed class DiscoveryService : IDiscoveryService
         await Task.CompletedTask;
     }
 
+    /// <inheritdoc/>
     public async Task StartListeningAsync(CancellationToken ct)
     {
         _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
@@ -82,6 +92,9 @@ public sealed class DiscoveryService : IDiscoveryService
         await Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Constructs a broadcast packet containing the magic bytes, session ID, TCP port, and hostname.
+    /// </summary>
     static byte[] BuildBroadcastPacket(MapSession session, int tcpPort)
     {
         var name = Environment.MachineName;
@@ -107,6 +120,10 @@ public sealed class DiscoveryService : IDiscoveryService
         return packet;
     }
 
+    /// <summary>
+    /// Parses a received UDP datagram and returns a <see cref="DiscoveredDm"/> if the packet
+    /// is valid, or <see langword="null"/> if the magic bytes are missing or the packet is truncated.
+    /// </summary>
     static DiscoveredDm? ParseBroadcastPacket(byte[] data, IPEndPoint sender)
     {
         if (data.Length < _magic.Length + 16 + 4 + 4)
@@ -138,6 +155,7 @@ public sealed class DiscoveryService : IDiscoveryService
         return new DiscoveredDm(name, tcpEndPoint, sessionId);
     }
 
+    /// <inheritdoc/>
     public void Dispose()
     {
         _cts?.Cancel();

--- a/DMap/Services/Networking/DmHostService.cs
+++ b/DMap/Services/Networking/DmHostService.cs
@@ -11,6 +11,12 @@ using DMap.Models;
 
 namespace DMap.Services.Networking;
 
+/// <summary>
+/// TCP server implementation of <see cref="IDmHostService"/>. Listens on an OS-assigned
+/// ephemeral port and manages a list of connected player <see cref="TcpClient"/> instances.
+/// Pending map image and session info are cached so newly connecting players receive the
+/// current state without an explicit re-send from the DM.
+/// </summary>
 public sealed class DmHostService : IDmHostService
 {
     TcpListener? _listener;
@@ -18,13 +24,22 @@ public sealed class DmHostService : IDmHostService
     readonly Lock _clientsLock = new();
     CancellationTokenSource? _cts;
 
+    /// <summary>Cached map image payload sent to new clients on connect, or <see langword="null"/> before the first map is loaded.</summary>
     byte[]? _pendingMapImage;
+
+    /// <summary>Cached session info payload sent to new clients on connect, or <see langword="null"/> before hosting starts.</summary>
     byte[]? _pendingSessionInfo;
 
+    /// <inheritdoc/>
     public int Port { get; set; }
+
+    /// <inheritdoc/>
     public int ConnectedPlayerCount => _clients.Count;
+
+    /// <inheritdoc/>
     public event EventHandler<int>? PlayerCountChanged;
 
+    /// <inheritdoc/>
     public async Task StartAsync(CancellationToken ct)
     {
         _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
@@ -52,6 +67,11 @@ public sealed class DmHostService : IDmHostService
         await Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Handles the lifetime of a single player connection: sends the cached session info and
+    /// map image on join, then keeps the connection alive until the client disconnects or the
+    /// service is cancelled.
+    /// </summary>
     async Task HandleClientAsync(TcpClient client)
     {
         lock (_clientsLock)
@@ -101,12 +121,14 @@ public sealed class DmHostService : IDmHostService
         }
     }
 
+    /// <inheritdoc/>
     public Task SendMapImageAsync(byte[] imageBytes, CancellationToken ct)
     {
         _pendingMapImage = imageBytes;
         return BroadcastAsync(MessageType.MapImage, imageBytes, ct);
     }
 
+    /// <inheritdoc/>
     public Task SendSessionInfoAsync(MapSession session, FogMask mask, CancellationToken ct)
     {
         using var ms = new MemoryStream();
@@ -125,12 +147,14 @@ public sealed class DmHostService : IDmHostService
         return BroadcastAsync(MessageType.SessionInfo, payload, ct);
     }
 
+    /// <inheritdoc/>
     public Task SendFogDeltaAsync(FogDelta delta, CancellationToken ct)
     {
         var payload = delta.Serialize();
         return BroadcastAsync(MessageType.FogDelta, payload, ct);
     }
 
+    /// <inheritdoc/>
     public Task SendFogFullAsync(FogMask mask, CancellationToken ct)
     {
         using var ms = new MemoryStream();
@@ -146,6 +170,11 @@ public sealed class DmHostService : IDmHostService
         return BroadcastAsync(MessageType.FogFull, ms.ToArray(), ct);
     }
 
+    /// <summary>
+    /// Sends a framed message to every currently connected player, taking a snapshot of the
+    /// client list under the lock to avoid holding it during I/O. Failed writes are silently
+    /// ignored because <see cref="HandleClientAsync"/> will clean up the disconnected client.
+    /// </summary>
     async Task BroadcastAsync(MessageType type, byte[] payload, CancellationToken ct)
     {
         List<TcpClient> snapshot;
@@ -168,6 +197,7 @@ public sealed class DmHostService : IDmHostService
         }
     }
 
+    /// <inheritdoc/>
     public void Dispose()
     {
         _cts?.Cancel();

--- a/DMap/Services/Networking/IDiscoveryService.cs
+++ b/DMap/Services/Networking/IDiscoveryService.cs
@@ -7,11 +7,40 @@ using DMap.Models;
 
 namespace DMap.Services.Networking;
 
+/// <summary>
+/// Represents a DM session discovered via UDP broadcast on the local network.
+/// </summary>
+/// <param name="Name">Human-readable name of the host machine (usually its hostname).</param>
+/// <param name="TcpEndPoint">IP endpoint of the DM's TCP server that players connect to.</param>
+/// <param name="SessionId">Unique identifier of the session, used to de-duplicate repeated broadcasts.</param>
 public sealed record DiscoveredDm(string Name, IPEndPoint TcpEndPoint, Guid SessionId);
 
+/// <summary>
+/// UDP-based discovery service that allows DM hosts to announce their presence on the
+/// local network and player clients to listen for those announcements.
+/// </summary>
 public interface IDiscoveryService : IDisposable
 {
+    /// <summary>
+    /// Starts broadcasting session availability packets via UDP every two seconds.
+    /// Should only be called by the DM host side.
+    /// </summary>
+    /// <param name="session">Session metadata to embed in each broadcast packet.</param>
+    /// <param name="tcpPort">TCP port players should connect to.</param>
+    /// <param name="ct">Cancellation token that stops broadcasting when cancelled.</param>
     Task StartBroadcastingAsync(MapSession session, int tcpPort, CancellationToken ct);
+
+    /// <summary>
+    /// Starts listening for DM broadcast packets on the discovery port.
+    /// Should only be called by the player client side.
+    /// </summary>
+    /// <param name="ct">Cancellation token that stops listening when cancelled.</param>
     Task StartListeningAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Raised each time a valid DM broadcast packet is received.
+    /// Consumers are responsible for de-duplicating by <see cref="DiscoveredDm.SessionId"/>
+    /// since the same DM broadcasts repeatedly.
+    /// </summary>
     event EventHandler<DiscoveredDm>? DmDiscovered;
 }

--- a/DMap/Services/Networking/IDmHostService.cs
+++ b/DMap/Services/Networking/IDmHostService.cs
@@ -6,15 +6,61 @@ using DMap.Models;
 
 namespace DMap.Services.Networking;
 
+/// <summary>
+/// TCP server that the DM (Dungeon Master) runs to stream map and fog data to connected player clients.
+/// </summary>
 public interface IDmHostService : IDisposable
 {
+    /// <summary>
+    /// The TCP port the listener is bound to. Only valid after <see cref="StartAsync"/> completes.
+    /// The OS assigns an ephemeral port when 0 is requested.
+    /// </summary>
     int Port { get; }
+
+    /// <summary>Number of player TCP connections currently open.</summary>
     int ConnectedPlayerCount { get; }
+
+    /// <summary>
+    /// Raised whenever a player connects or disconnects.
+    /// The event argument is the new total connected player count.
+    /// </summary>
     event EventHandler<int>? PlayerCountChanged;
 
+    /// <summary>
+    /// Starts the TCP listener and begins accepting incoming player connections in the background.
+    /// </summary>
+    /// <param name="ct">Cancellation token that stops the listener when cancelled.</param>
     Task StartAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Broadcasts the map image to all currently connected players and caches it so
+    /// newly connecting players also receive it on join.
+    /// </summary>
+    /// <param name="imageBytes">Raw image file bytes (PNG, JPEG, etc.).</param>
+    /// <param name="ct">Cancellation token.</param>
     Task SendMapImageAsync(byte[] imageBytes, CancellationToken ct);
+
+    /// <summary>
+    /// Broadcasts the session info and the full current fog mask to all connected players,
+    /// and caches the payload for players that connect later.
+    /// </summary>
+    /// <param name="session">Session identifier and map dimensions.</param>
+    /// <param name="mask">Current fog mask to include in the handshake payload.</param>
+    /// <param name="ct">Cancellation token.</param>
     Task SendSessionInfoAsync(MapSession session, FogMask mask, CancellationToken ct);
+
+    /// <summary>
+    /// Broadcasts a fog delta (incremental update) to all connected players.
+    /// Deltas are not cached because new players receive the full fog state via <see cref="SendSessionInfoAsync"/>.
+    /// </summary>
+    /// <param name="delta">The changed fog region to transmit.</param>
+    /// <param name="ct">Cancellation token.</param>
     Task SendFogDeltaAsync(FogDelta delta, CancellationToken ct);
+
+    /// <summary>
+    /// Broadcasts a full fog mask replacement to all connected players.
+    /// </summary>
+    /// <param name="mask">The complete fog mask to send.</param>
+    /// <param name="ct">Cancellation token.</param>
     Task SendFogFullAsync(FogMask mask, CancellationToken ct);
 }

--- a/DMap/Services/Networking/IPlayerClientService.cs
+++ b/DMap/Services/Networking/IPlayerClientService.cs
@@ -7,14 +7,53 @@ using DMap.Models;
 
 namespace DMap.Services.Networking;
 
+/// <summary>
+/// TCP client used by the player to connect to a DM host and receive map and fog updates.
+/// </summary>
 public interface IPlayerClientService : IDisposable
 {
+    /// <summary>
+    /// Raised when a <see cref="MessageType.SessionInfo"/> frame is received.
+    /// The event argument contains the session ID and map dimensions.
+    /// The full fog mask for the session is delivered separately via <see cref="FogFullReceived"/>.
+    /// </summary>
     event EventHandler<MapSession>? SessionInfoReceived;
+
+    /// <summary>
+    /// Raised when a <see cref="MessageType.MapImage"/> frame is received.
+    /// The event argument is the raw image file bytes suitable for decoding into a bitmap.
+    /// </summary>
     event EventHandler<byte[]>? MapImageReceived;
+
+    /// <summary>
+    /// Raised when a <see cref="MessageType.FogDelta"/> frame is received.
+    /// The event argument is the deserialized incremental fog region.
+    /// </summary>
     event EventHandler<FogDelta>? FogDeltaReceived;
+
+    /// <summary>
+    /// Raised when a <see cref="MessageType.FogFull"/> frame is received, or when session
+    /// info is first received (which includes the full fog state).
+    /// The event argument is a fully reconstructed fog mask.
+    /// </summary>
     event EventHandler<FogMask>? FogFullReceived;
+
+    /// <summary>
+    /// Raised when the connection to the DM is closed, either because the DM disconnected,
+    /// the network failed, or <see cref="DisconnectAsync"/> was called.
+    /// </summary>
     event EventHandler? Disconnected;
 
+    /// <summary>
+    /// Opens a TCP connection to the DM at <paramref name="endpoint"/> and starts the
+    /// background receive loop.
+    /// </summary>
+    /// <param name="endpoint">IP address and port of the DM host.</param>
+    /// <param name="ct">Cancellation token.</param>
     Task ConnectAsync(IPEndPoint endpoint, CancellationToken ct);
+
+    /// <summary>
+    /// Cancels the receive loop and closes the TCP connection.
+    /// </summary>
     Task DisconnectAsync();
 }

--- a/DMap/Services/Networking/PlayerClientService.cs
+++ b/DMap/Services/Networking/PlayerClientService.cs
@@ -10,17 +10,32 @@ using DMap.Models;
 
 namespace DMap.Services.Networking;
 
+/// <summary>
+/// Default implementation of <see cref="IPlayerClientService"/>. Connects to the DM's TCP
+/// host and drives a background receive loop that deserializes incoming frames and fires the
+/// appropriate events on the caller's thread.
+/// </summary>
 public sealed class PlayerClientService : IPlayerClientService
 {
     TcpClient? _client;
     CancellationTokenSource? _cts;
 
+    /// <inheritdoc/>
     public event EventHandler<MapSession>? SessionInfoReceived;
+
+    /// <inheritdoc/>
     public event EventHandler<byte[]>? MapImageReceived;
+
+    /// <inheritdoc/>
     public event EventHandler<FogDelta>? FogDeltaReceived;
+
+    /// <inheritdoc/>
     public event EventHandler<FogMask>? FogFullReceived;
+
+    /// <inheritdoc/>
     public event EventHandler? Disconnected;
 
+    /// <inheritdoc/>
     public async Task ConnectAsync(IPEndPoint endpoint, CancellationToken ct)
     {
         _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
@@ -30,6 +45,11 @@ public sealed class PlayerClientService : IPlayerClientService
         _ = Task.Run(() => ReceiveLoopAsync(_client.GetStream()), _cts.Token);
     }
 
+    /// <summary>
+    /// Continuously reads framed messages from <paramref name="stream"/> and dispatches
+    /// them to the appropriate handler until the connection closes or the token is cancelled.
+    /// Always fires <see cref="Disconnected"/> when the loop exits.
+    /// </summary>
     async Task ReceiveLoopAsync(NetworkStream stream)
     {
         try
@@ -71,6 +91,11 @@ public sealed class PlayerClientService : IPlayerClientService
         Disconnected?.Invoke(this, EventArgs.Empty);
     }
 
+    /// <summary>
+    /// Deserializes a <see cref="MessageType.SessionInfo"/> payload, fires
+    /// <see cref="SessionInfoReceived"/> with the session metadata, and then fires
+    /// <see cref="FogFullReceived"/> with the embedded initial fog mask.
+    /// </summary>
     void HandleSessionInfo(byte[] payload)
     {
         using var ms = new MemoryStream(payload);
@@ -92,12 +117,18 @@ public sealed class PlayerClientService : IPlayerClientService
         FogFullReceived?.Invoke(this, mask);
     }
 
+    /// <summary>
+    /// Deserializes a <see cref="MessageType.FogDelta"/> payload and fires <see cref="FogDeltaReceived"/>.
+    /// </summary>
     void HandleFogDelta(byte[] payload)
     {
         var delta = FogDelta.Deserialize(payload);
         FogDeltaReceived?.Invoke(this, delta);
     }
 
+    /// <summary>
+    /// Deserializes a <see cref="MessageType.FogFull"/> payload and fires <see cref="FogFullReceived"/>.
+    /// </summary>
     void HandleFogFull(byte[] payload)
     {
         using var ms = new MemoryStream(payload);
@@ -114,6 +145,7 @@ public sealed class PlayerClientService : IPlayerClientService
         FogFullReceived?.Invoke(this, mask);
     }
 
+    /// <inheritdoc/>
     public async Task DisconnectAsync()
     {
         _cts?.Cancel();
@@ -122,6 +154,7 @@ public sealed class PlayerClientService : IPlayerClientService
         await Task.CompletedTask;
     }
 
+    /// <inheritdoc/>
     public void Dispose()
     {
         _cts?.Cancel();

--- a/DMap/Services/Networking/Protocol.cs
+++ b/DMap/Services/Networking/Protocol.cs
@@ -6,22 +6,57 @@ using DMap.Models;
 
 namespace DMap.Services.Networking;
 
+/// <summary>
+/// Identifies the type of a framed network message exchanged between the DM host and player clients.
+/// </summary>
 public enum MessageType
 {
+    /// <summary>Initial session handshake carrying session ID, map dimensions, and the full fog mask.</summary>
     SessionInfo = 1,
+
+    /// <summary>Raw image bytes for the map background, sent once per session.</summary>
     MapImage = 2,
+
+    /// <summary>A compressed rectangular region of fog mask changes (incremental update).</summary>
     FogDelta = 3,
+
+    /// <summary>A compressed full fog mask replacement.</summary>
     FogFull = 4
 }
 
+/// <summary>
+/// A rectangular region of fog mask data that can be serialized for network transmission.
+/// Used for incremental fog updates so only the changed area is sent over the wire.
+/// </summary>
 public sealed class FogDelta
 {
+    /// <summary>Left edge of the region in map pixels.</summary>
     public int X { get; init; }
+
+    /// <summary>Top edge of the region in map pixels.</summary>
     public int Y { get; init; }
+
+    /// <summary>Width of the region in pixels.</summary>
     public int Width { get; init; }
+
+    /// <summary>Height of the region in pixels.</summary>
     public int Height { get; init; }
+
+    /// <summary>
+    /// Row-major fog pixel values for the region (Width * Height bytes).
+    /// Each byte is the reveal value: 0 = fully fogged, 255 = fully revealed.
+    /// </summary>
     public byte[] Data { get; init; } = Array.Empty<byte>();
 
+    /// <summary>
+    /// Extracts a rectangular region from <paramref name="mask"/> into a new <see cref="FogDelta"/>.
+    /// Pixels outside mask bounds are written as 0.
+    /// </summary>
+    /// <param name="mask">Source fog mask.</param>
+    /// <param name="x">Left edge of the region.</param>
+    /// <param name="y">Top edge of the region.</param>
+    /// <param name="width">Width of the region.</param>
+    /// <param name="height">Height of the region.</param>
     public static FogDelta FromMask(FogMask mask, int x, int y, int width, int height)
     {
         var data = new byte[width * height];
@@ -39,6 +74,10 @@ public sealed class FogDelta
         return new FogDelta { X = x, Y = y, Width = width, Height = height, Data = data };
     }
 
+    /// <summary>
+    /// Serializes this delta to a byte array.
+    /// Format: X (4 bytes) | Y (4 bytes) | Width (4 bytes) | Height (4 bytes) | Deflate-compressed pixel data.
+    /// </summary>
     public byte[] Serialize()
     {
         using var ms = new MemoryStream();
@@ -56,6 +95,10 @@ public sealed class FogDelta
         return ms.ToArray();
     }
 
+    /// <summary>
+    /// Reconstructs a <see cref="FogDelta"/> from the byte array produced by <see cref="Serialize"/>.
+    /// </summary>
+    /// <param name="bytes">Serialized delta bytes.</param>
     public static FogDelta Deserialize(byte[] bytes)
     {
         using var ms = new MemoryStream(bytes);
@@ -73,8 +116,19 @@ public sealed class FogDelta
     }
 }
 
+/// <summary>
+/// Utilities for framing and reading length-prefixed messages over a TCP stream.
+/// Each frame has an 8-byte header: 4-byte <see cref="MessageType"/> (little-endian int32)
+/// followed by a 4-byte payload length (little-endian int32), then the raw payload bytes.
+/// </summary>
 public static class ProtocolFraming
 {
+    /// <summary>
+    /// Creates a framed byte array containing the 8-byte header and <paramref name="payload"/> concatenated.
+    /// </summary>
+    /// <param name="type">Message type written into bytes 0–3 of the header.</param>
+    /// <param name="payload">The message body.</param>
+    /// <returns>A single buffer ready to write to a stream.</returns>
     public static byte[] Frame(MessageType type, byte[] payload)
     {
         var frame = new byte[8 + payload.Length];
@@ -84,6 +138,14 @@ public static class ProtocolFraming
         return frame;
     }
 
+    /// <summary>
+    /// Asynchronously writes a framed message to <paramref name="stream"/> and flushes it.
+    /// The header and payload are sent as separate write calls to avoid large buffer allocations.
+    /// </summary>
+    /// <param name="stream">Writable network stream.</param>
+    /// <param name="type">Message type.</param>
+    /// <param name="payload">Message body.</param>
+    /// <param name="ct">Cancellation token.</param>
     public static async System.Threading.Tasks.Task WriteFrameAsync(
         Stream stream, MessageType type, byte[] payload,
         System.Threading.CancellationToken ct = default)
@@ -96,6 +158,16 @@ public static class ProtocolFraming
         await stream.FlushAsync(ct).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Asynchronously reads one framed message from <paramref name="stream"/>.
+    /// Handles partial reads by looping until all expected bytes are received.
+    /// </summary>
+    /// <param name="stream">Readable network stream.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// The decoded message type and payload, or <see langword="null"/> if the stream
+    /// was closed before the full frame could be read.
+    /// </returns>
     public static async System.Threading.Tasks.Task<(MessageType Type, byte[] Payload)?> ReadFrameAsync(
         Stream stream, System.Threading.CancellationToken ct = default)
     {

--- a/DMap/ViewModels/DmViewModel.cs
+++ b/DMap/ViewModels/DmViewModel.cs
@@ -20,6 +20,11 @@ using ReactiveUI;
 
 namespace DMap.ViewModels;
 
+/// <summary>
+/// ViewModel for the Dungeon Master (DM) view. Owns the fog mask, undo/redo history,
+/// networking services, and all toolbar commands. Bridges user input events from
+/// <see cref="Controls.MapCanvas"/> to the underlying fog and networking services.
+/// </summary>
 public class DmViewModel : ViewModelBase, IDisposable
 {
     const int DefaultBrushDiameter = 50;
@@ -47,54 +52,69 @@ public class DmViewModel : ViewModelBase, IDisposable
     readonly IDiscoveryService _discoveryService;
     readonly Func<PlayerViewModel> _createPlayer;
 
+    /// <summary>The decoded map background image, or <see langword="null"/> before a map is loaded.</summary>
     public Bitmap? MapImage
     {
         get;
         private set => this.RaiseAndSetIfChanged(ref field, value);
     }
 
+    /// <summary><see langword="true"/> once a map image has been loaded and the fog mask has been initialised.</summary>
     public bool IsMapLoaded
     {
         get;
         private set => this.RaiseAndSetIfChanged(ref field, value);
     }
 
+    /// <summary>
+    /// The current fog mask, kept in sync with the fog service.
+    /// Bound to the map canvas so it can rebuild its fog bitmap when the mask is replaced.
+    /// </summary>
     public FogMask? FogMask
     {
         get;
         private set => this.RaiseAndSetIfChanged(ref field, value);
     }
 
+    /// <summary>Diameter of the brush in map pixels. Bound to the toolbar slider.</summary>
     public int BrushDiameter
     {
         get;
         set => this.RaiseAndSetIfChanged(ref field, value);
     } = DefaultBrushDiameter;
 
+    /// <summary>Brush edge softness in [0, 1]; 0 = hard edge, 1 = full gradient.</summary>
     public double BrushSoftness
     {
         get;
         set => this.RaiseAndSetIfChanged(ref field, value);
     } = DefaultBrushSoftness;
 
+    /// <summary>Maximum brush opacity applied per stroke in [0, 1].</summary>
     public double BrushOpacity
     {
         get;
         set => this.RaiseAndSetIfChanged(ref field, value);
     } = DefaultBrushOpacity;
 
+    /// <summary>Shape edge softness in [0, 1]; 0 = hard edge.</summary>
     public double ShapeSoftness
     {
         get;
         set => this.RaiseAndSetIfChanged(ref field, value);
     } = DefaultShapeSoftness;
 
+    /// <summary>Maximum shape fill opacity in [0, 1].</summary>
     public double ShapeOpacity
     {
         get;
         set => this.RaiseAndSetIfChanged(ref field, value);
     } = DefaultShapeOpacity;
 
+    /// <summary>
+    /// Opacity of the fog overlay rendered on the canvas, in the range [0, 255].
+    /// Changing this value also raises <see cref="FogOpacityPercent"/> change notification.
+    /// </summary>
     public byte FogOpacity
     {
         get;
@@ -105,24 +125,34 @@ public class DmViewModel : ViewModelBase, IDisposable
         }
     } = DefaultFogOpacity;
 
+    /// <summary>
+    /// <see cref="FogOpacity"/> expressed as a percentage in [0, 100], rounded to the nearest integer.
+    /// Setting this property converts the value back to a byte and updates <see cref="FogOpacity"/>.
+    /// </summary>
     public decimal FogOpacityPercent
     {
         get => (decimal)Math.Round(FogOpacity / 255.0 * 100);
         set => FogOpacity = (byte)Math.Clamp(Math.Round((double)value / 100.0 * 255), MinFogOpacity, MaxFogOpacity);
     }
 
+    /// <summary>Horizontal pan offset of the map canvas in screen pixels.</summary>
     public double OffsetX
     {
         get;
         set => this.RaiseAndSetIfChanged(ref field, value);
     }
 
+    /// <summary>Vertical pan offset of the map canvas in screen pixels.</summary>
     public double OffsetY
     {
         get;
         set => this.RaiseAndSetIfChanged(ref field, value);
     }
 
+    /// <summary>
+    /// Current zoom multiplier applied to the canvas transform.
+    /// Changing this value also raises <see cref="ZoomPercent"/> change notification.
+    /// </summary>
     public double ZoomLevel
     {
         get;
@@ -133,24 +163,35 @@ public class DmViewModel : ViewModelBase, IDisposable
         }
     } = DefaultZoomLevel;
 
+    /// <summary>
+    /// <see cref="ZoomLevel"/> expressed as a percentage in [10, 1000], rounded to the nearest integer.
+    /// Setting this property converts the value and clamps it within allowed bounds.
+    /// </summary>
     public decimal ZoomPercent
     {
         get => (decimal)Math.Round(ZoomLevel * 100);
         set => ZoomLevel = Math.Clamp((double)value / 100.0, MinZoomLevel, MaxZoomLevel);
     }
 
+    /// <summary>Number of player TCP connections currently open on the host service.</summary>
     public int ConnectedPlayers
     {
         get;
         set => this.RaiseAndSetIfChanged(ref field, value);
     }
 
+    /// <summary>Current process memory usage formatted as a human-readable string (e.g. "42 MB"), updated every 2 seconds.</summary>
     public string MemoryUsage
     {
         get;
         private set => this.RaiseAndSetIfChanged(ref field, value);
     } = string.Empty;
 
+    /// <summary>
+    /// The currently active editing tool.
+    /// Changing this value also raises change notifications for the derived
+    /// <see cref="IsBrushSelected"/>, <see cref="IsShapeSelected"/>, and <see cref="IsPanSelected"/> properties.
+    /// </summary>
     public ToolType SelectedTool
     {
         get;
@@ -163,64 +204,124 @@ public class DmViewModel : ViewModelBase, IDisposable
         }
     }
 
+    /// <summary><see langword="true"/> when the Brush tool is active.</summary>
     public bool IsBrushSelected => SelectedTool == ToolType.Brush;
+
+    /// <summary><see langword="true"/> when the Shape tool is active.</summary>
     public bool IsShapeSelected => SelectedTool == ToolType.Shape;
+
+    /// <summary><see langword="true"/> when the Pan tool is active.</summary>
     public bool IsPanSelected => SelectedTool == ToolType.Pan;
 
+    /// <summary>The brush shape (circle, square, or diamond) used when the Brush tool is active.</summary>
     public BrushShape SelectedBrushShape
     {
         get;
         set => this.RaiseAndSetIfChanged(ref field, value);
     }
 
+    /// <summary>All available tool types, used to populate the toolbar's tool selector.</summary>
     public IReadOnlyList<ToolType> ToolTypes { get; } = Enum.GetValues<ToolType>();
+
+    /// <summary>All available brush shapes, used to populate the brush shape selector.</summary>
     public IReadOnlyList<BrushShape> BrushShapes { get; } = Enum.GetValues<BrushShape>();
 
+    /// <summary>The geometric shape drawn when the Shape tool is active.</summary>
     public ShapeType SelectedShapeType
     {
         get;
         set => this.RaiseAndSetIfChanged(ref field, value);
     }
 
+    /// <summary>All available shape types, used to populate the shape type selector.</summary>
     public IReadOnlyList<ShapeType> ShapeTypes { get; } = Enum.GetValues<ShapeType>();
 
+    /// <summary><see langword="true"/> when at least one operation is available to undo.</summary>
     public bool CanUndo
     {
         get;
         private set => this.RaiseAndSetIfChanged(ref field, value);
     }
 
+    /// <summary><see langword="true"/> when at least one operation is available to redo.</summary>
     public bool CanRedo
     {
         get;
         private set => this.RaiseAndSetIfChanged(ref field, value);
     }
 
+    /// <summary>Opens a file picker and loads the selected image as the map background.</summary>
     public ReactiveCommand<Unit, Unit> LoadMapCommand { get; }
+
+    /// <summary>Increases the zoom level by 20%.</summary>
     public ReactiveCommand<Unit, Unit> ZoomInCommand { get; }
+
+    /// <summary>Decreases the zoom level by ~17%.</summary>
     public ReactiveCommand<Unit, Unit> ZoomOutCommand { get; }
+
+    /// <summary>Resets zoom to 100% and clears the pan offset.</summary>
     public ReactiveCommand<Unit, Unit> ResetViewCommand { get; }
+
+    /// <summary>Activates the Brush tool.</summary>
     public ReactiveCommand<Unit, Unit> SelectBrushCommand { get; }
+
+    /// <summary>Activates the Shape tool.</summary>
     public ReactiveCommand<Unit, Unit> SelectShapeCommand { get; }
+
+    /// <summary>Activates the Pan tool.</summary>
     public ReactiveCommand<Unit, Unit> SelectPanCommand { get; }
+
+    /// <summary>Sets all fog mask pixels to 255 (fully revealed) and pushes an undo entry.</summary>
     public ReactiveCommand<Unit, Unit> RevealAllCommand { get; }
+
+    /// <summary>Sets all fog mask pixels to 0 (fully fogged) and pushes an undo entry.</summary>
     public ReactiveCommand<Unit, Unit> RefogAllCommand { get; }
+
+    /// <summary>Shuts down the application.</summary>
     public ReactiveCommand<Unit, Unit> ExitCommand { get; }
+
+    /// <summary>Undoes the most recent fog operation.</summary>
     public ReactiveCommand<Unit, Unit> UndoCommand { get; }
+
+    /// <summary>Redoes the most recently undone fog operation.</summary>
     public ReactiveCommand<Unit, Unit> RedoCommand { get; }
+
+    /// <summary>Increases <see cref="FogOpacityPercent"/> by one step.</summary>
     public ReactiveCommand<Unit, Unit> FogOpacityUpCommand { get; }
+
+    /// <summary>Decreases <see cref="FogOpacityPercent"/> by one step.</summary>
     public ReactiveCommand<Unit, Unit> FogOpacityDownCommand { get; }
+
+    /// <summary>Opens the player discovery window so the DM can monitor connected players.</summary>
     public ReactiveCommand<Unit, Unit> OpenPlayerWindowCommand { get; }
 
+    /// <summary>
+    /// Interaction that requests the view to display a file picker and return the chosen path.
+    /// Handled in <see cref="Views.DmView"/>.
+    /// </summary>
     public Interaction<Unit, string?> ShowOpenFileDialog { get; } = new();
+
+    /// <summary>
+    /// Interaction that requests the view to display the player window for the given ViewModel.
+    /// Handled in <see cref="Views.DmView"/>.
+    /// </summary>
     public Interaction<PlayerViewModel, Unit> ShowPlayerWindow { get; } = new();
 
+    /// <summary>
+    /// Raised after any fog modification (brush, shape, undo, redo, reveal-all, refog-all).
+    /// The event argument is the bounding rectangle of the changed region. The view uses
+    /// this to update only the affected portion of the fog bitmap rather than rebuilding it entirely.
+    /// </summary>
     public event EventHandler<PixelRect>? FogUpdated;
 
     byte[]? _mapImageBytes;
     MapSession? _session;
+    /// <summary>Fires every 2 seconds on the UI thread to refresh <see cref="MemoryUsage"/>.</summary>
     readonly DispatcherTimer _memoryTimer;
 
+    /// <summary>
+    /// Constructs the ViewModel and wires up all reactive commands and service event handlers.
+    /// </summary>
     public DmViewModel(IFogMaskService fogService, IUndoRedoService undoRedo, IDmHostService hostService, IDiscoveryService discoveryService, Func<PlayerViewModel> createPlayer)
     {
         _fogService = fogService;
@@ -265,6 +366,10 @@ public class DmViewModel : ViewModelBase, IDisposable
         OpenPlayerWindowCommand = ReactiveCommand.CreateFromTask(OpenPlayerWindowAsync);
     }
 
+    /// <summary>
+    /// Creates a <see cref="PlayerViewModel"/>, starts discovery listening, and triggers the
+    /// <see cref="ShowPlayerWindow"/> interaction so the view can open the player window.
+    /// </summary>
     async Task OpenPlayerWindowAsync()
     {
         var playerVm = _createPlayer();
@@ -272,6 +377,9 @@ public class DmViewModel : ViewModelBase, IDisposable
         await ShowPlayerWindow.Handle(playerVm);
     }
 
+    /// <summary>
+    /// Reveals the entire map, captures a before/after undo entry, and broadcasts the change.
+    /// </summary>
     void ExecuteRevealAll()
     {
         if (_fogService.Mask is null)
@@ -286,6 +394,9 @@ public class DmViewModel : ViewModelBase, IDisposable
         SendFogDelta(rect);
     }
 
+    /// <summary>
+    /// Re-fogs the entire map, captures a before/after undo entry, and broadcasts the change.
+    /// </summary>
     void ExecuteRefogAll()
     {
         if (_fogService.Mask is null)
@@ -300,6 +411,9 @@ public class DmViewModel : ViewModelBase, IDisposable
         SendFogDelta(rect);
     }
 
+    /// <summary>
+    /// Pops the most recent command from the undo stack, restores the before-state, and broadcasts the delta.
+    /// </summary>
     void ExecuteUndo()
     {
         if (_fogService.Mask is null)
@@ -314,6 +428,9 @@ public class DmViewModel : ViewModelBase, IDisposable
         SendFogDelta(command.DirtyRect);
     }
 
+    /// <summary>
+    /// Pops the most recently undone command from the redo stack, re-applies it, and broadcasts the delta.
+    /// </summary>
     void ExecuteRedo()
     {
         if (_fogService.Mask is null)
@@ -328,6 +445,10 @@ public class DmViewModel : ViewModelBase, IDisposable
         SendFogDelta(command.DirtyRect);
     }
 
+    /// <summary>
+    /// Opens the file picker via <see cref="ShowOpenFileDialog"/>, loads the chosen image as the
+    /// map background, initialises the fog mask, and starts hosting.
+    /// </summary>
     async Task LoadMapAsync()
     {
         var path = await ShowOpenFileDialog.Handle(Unit.Default);
@@ -351,11 +472,20 @@ public class DmViewModel : ViewModelBase, IDisposable
         await StartHostingAsync();
     }
 
+    /// <summary>Returns the current process working set formatted as "<c>N MB</c>".</summary>
     static string FormatMemoryUsage() =>
         $"{Environment.WorkingSet / 1024 / 1024} MB";
 
+    /// <summary>
+    /// Called by the view when the user begins a brush stroke (pointer pressed).
+    /// Snapshots the current mask for opacity-consistent painting.
+    /// </summary>
     public void BeginBrushStroke() => _fogService.BeginStroke();
 
+    /// <summary>
+    /// Called by the view when the user ends a brush stroke (pointer released).
+    /// Finalises the stroke and pushes a undo entry if any pixels changed.
+    /// </summary>
     public void EndBrushStroke()
     {
         var command = _fogService.EndStroke();
@@ -363,6 +493,15 @@ public class DmViewModel : ViewModelBase, IDisposable
             _undoRedo.Push(command);
     }
 
+    /// <summary>
+    /// Called by the view when the user completes a shape drag gesture.
+    /// Applies the selected shape to the fog mask, records an undo entry, and broadcasts the delta.
+    /// </summary>
+    /// <param name="x1">Start X in map pixels.</param>
+    /// <param name="y1">Start Y in map pixels.</param>
+    /// <param name="x2">End X in map pixels.</param>
+    /// <param name="y2">End Y in map pixels.</param>
+    /// <param name="isErasing"><see langword="true"/> to erase fog; <see langword="false"/> to reveal.</param>
     public void OnShapeStroke(int x1, int y1, int x2, int y2, bool isErasing)
     {
         if (_fogService.Mask is null)
@@ -384,6 +523,9 @@ public class DmViewModel : ViewModelBase, IDisposable
         SendFogDelta(dirtyRect);
     }
 
+    /// <summary>
+    /// Computes the clamped bounding rectangle of a shape defined by two corner points.
+    /// </summary>
     PixelRect ComputeShapeRect(int x1, int y1, int x2, int y2)
     {
         var minX = Math.Max(0, Math.Min(x1, x2));
@@ -393,6 +535,10 @@ public class DmViewModel : ViewModelBase, IDisposable
         return new PixelRect(minX, minY, maxX - minX + 1, maxY - minY + 1);
     }
 
+    /// <summary>
+    /// For square and circle shape types, constrains the drag so the resulting shape has equal
+    /// width and height (the smaller of the two extents is used). Other shape types are returned unchanged.
+    /// </summary>
     static (int, int, int, int) ConstrainToSquare(ShapeType shapeType, int x1, int y1, int x2, int y2)
     {
         if (shapeType is not ShapeType.Square and not ShapeType.Circle)
@@ -402,6 +548,15 @@ public class DmViewModel : ViewModelBase, IDisposable
         return (x1, y1, x1 + Math.Sign(x2 - x1) * side, y1 + Math.Sign(y2 - y1) * side);
     }
 
+    /// <summary>
+    /// Called by the view for each pointer-move event while a brush stroke is in progress.
+    /// Applies the selected brush between the previous and current map coordinates and broadcasts the change.
+    /// </summary>
+    /// <param name="x1">Previous map X in pixels.</param>
+    /// <param name="y1">Previous map Y in pixels.</param>
+    /// <param name="x2">Current map X in pixels.</param>
+    /// <param name="y2">Current map Y in pixels.</param>
+    /// <param name="isErasing"><see langword="true"/> to erase fog; <see langword="false"/> to reveal.</param>
     public void OnBrushStroke(int x1, int y1, int x2, int y2, bool isErasing)
     {
         if (_fogService.Mask is null)
@@ -420,6 +575,10 @@ public class DmViewModel : ViewModelBase, IDisposable
         SendFogDelta(dirtyRect);
     }
 
+    /// <summary>
+    /// Extracts the fog delta for <paramref name="dirtyRect"/> from the current mask and
+    /// fires-and-forgets a broadcast to all connected players.
+    /// </summary>
     void SendFogDelta(PixelRect dirtyRect)
     {
         if (_fogService.Mask is null)
@@ -431,6 +590,10 @@ public class DmViewModel : ViewModelBase, IDisposable
         _ = _hostService.SendFogDeltaAsync(delta, default);
     }
 
+    /// <summary>
+    /// Starts the TCP host, sends the current map image and session info to any already-connected
+    /// players, and begins broadcasting the session over UDP for discovery.
+    /// </summary>
     async Task StartHostingAsync()
     {
         if (_session is null)
@@ -447,12 +610,14 @@ public class DmViewModel : ViewModelBase, IDisposable
         await _discoveryService.StartBroadcastingAsync(_session, _hostService.Port, default);
     }
 
+    /// <inheritdoc/>
     public void Dispose()
     {
         Dispose(disposing: true);
         GC.SuppressFinalize(this);
     }
 
+    /// <summary>Releases managed resources when <paramref name="disposing"/> is <see langword="true"/>.</summary>
     protected virtual void Dispose(bool disposing)
     {
         if (disposing)

--- a/DMap/ViewModels/MainWindowViewModel.cs
+++ b/DMap/ViewModels/MainWindowViewModel.cs
@@ -4,8 +4,18 @@ using ReactiveUI;
 
 namespace DMap.ViewModels;
 
+/// <summary>
+/// ViewModel for the application's main window.
+/// Hosts the active top-level view (currently always the DM view) as a swappable
+/// <see cref="Content"/> control so the window shell can remain independent of
+/// which view is displayed.
+/// </summary>
 public class MainWindowViewModel : ViewModelBase
 {
+    /// <summary>
+    /// The control currently displayed inside the main window.
+    /// Setting this property triggers a UI update via <see cref="ReactiveUI.IReactiveObject"/>.
+    /// </summary>
     public Control? Content
     {
         get;

--- a/DMap/ViewModels/PlayerViewModel.cs
+++ b/DMap/ViewModels/PlayerViewModel.cs
@@ -16,73 +16,110 @@ using ReactiveUI;
 
 namespace DMap.ViewModels;
 
+/// <summary>
+/// ViewModel for the player view. Manages DM discovery, connection state, and incoming
+/// map and fog updates from the DM host. All network callbacks are marshalled to the UI
+/// thread via <see cref="Dispatcher.UIThread"/>.
+/// </summary>
 public class PlayerViewModel : ViewModelBase, IDisposable
 {
     readonly IFogMaskService _fogService;
     readonly IDiscoveryService _discoveryService;
     readonly IPlayerClientService _clientService;
 
+    /// <summary>
+    /// Live collection of DM sessions discovered via UDP broadcast.
+    /// De-duplicated by <see cref="DiscoveredDm.SessionId"/> before adding.
+    /// </summary>
     public ObservableCollection<DiscoveredDm> DiscoveredDms { get; } = new();
 
+    /// <summary>The DM session selected in the discovery list, or <see langword="null"/> if none is selected.</summary>
     public DiscoveredDm? SelectedDm
     {
         get;
         set => this.RaiseAndSetIfChanged(ref field, value);
     }
 
+    /// <summary><see langword="true"/> when a TCP connection to the DM is open.</summary>
     public bool IsConnected
     {
         get;
         private set => this.RaiseAndSetIfChanged(ref field, value);
     }
 
+    /// <summary><see langword="true"/> while a connection attempt is in progress.</summary>
     public bool IsConnecting
     {
         get;
         private set => this.RaiseAndSetIfChanged(ref field, value);
     }
 
+    /// <summary>Human-readable status message shown in the player window (e.g. discovery state, connection result).</summary>
     public string StatusText
     {
         get;
         private set => this.RaiseAndSetIfChanged(ref field, value);
     } = "Searching for DM sessions...";
 
+    /// <summary>The decoded map background image received from the DM, or <see langword="null"/> before the first map arrives.</summary>
     public Bitmap? MapImage
     {
         get;
         private set => this.RaiseAndSetIfChanged(ref field, value);
     }
 
+    /// <summary>
+    /// The fog mask maintained by the local fog service, kept in sync with updates received from the DM.
+    /// Bound to the map canvas to trigger fog bitmap rebuilds when the mask is replaced.
+    /// </summary>
     public FogMask? FogMask
     {
         get;
         private set => this.RaiseAndSetIfChanged(ref field, value);
     }
 
+    /// <summary>Horizontal pan offset of the map canvas in screen pixels.</summary>
     public double OffsetX
     {
         get;
         set => this.RaiseAndSetIfChanged(ref field, value);
     }
 
+    /// <summary>Vertical pan offset of the map canvas in screen pixels.</summary>
     public double OffsetY
     {
         get;
         set => this.RaiseAndSetIfChanged(ref field, value);
     }
 
+    /// <summary>Current zoom multiplier applied to the canvas transform.</summary>
     public double ZoomLevel
     {
         get;
         set => this.RaiseAndSetIfChanged(ref field, value);
     } = 1.0;
 
+    /// <summary>
+    /// Initiates a connection to <see cref="SelectedDm"/>.
+    /// Enabled only when a DM is selected and no connection is active or pending.
+    /// </summary>
     public ReactiveCommand<Unit, Unit> ConnectCommand { get; }
+
+    /// <summary>
+    /// Closes the current connection to the DM.
+    /// Enabled only when <see cref="IsConnected"/> is <see langword="true"/>.
+    /// </summary>
     public ReactiveCommand<Unit, Unit> DisconnectCommand { get; }
 
+    /// <summary>
+    /// Raised after any fog update (initial session fog, incremental delta, or full replacement).
+    /// The event argument is the bounding rectangle of the changed region.
+    /// </summary>
     public event EventHandler<PixelRect>? FogUpdated;
 
+    /// <summary>
+    /// Constructs the ViewModel and subscribes to all discovery and client service events.
+    /// </summary>
     public PlayerViewModel(IFogMaskService fogService, IDiscoveryService discoveryService, IPlayerClientService clientService)
     {
         _fogService = fogService;
@@ -106,11 +143,18 @@ public class PlayerViewModel : ViewModelBase, IDisposable
         DisconnectCommand = ReactiveCommand.CreateFromTask(DisconnectAsync, canDisconnect);
     }
 
+    /// <summary>
+    /// Starts listening for DM UDP broadcast packets. Should be called before showing the player window.
+    /// </summary>
     public async Task StartDiscoveryAsync()
     {
         await _discoveryService.StartListeningAsync(default);
     }
 
+    /// <summary>
+    /// Adds the discovered DM to <see cref="DiscoveredDms"/> if its session ID has not already been seen.
+    /// Marshalled to the UI thread because the discovery service fires on a background thread.
+    /// </summary>
     void OnDmDiscovered(object? sender, DiscoveredDm dm)
     {
         Dispatcher.UIThread.Post(() =>
@@ -125,6 +169,9 @@ public class PlayerViewModel : ViewModelBase, IDisposable
         });
     }
 
+    /// <summary>
+    /// Connects to <see cref="SelectedDm"/> and updates connection state and status text.
+    /// </summary>
     async Task ConnectAsync()
     {
         if (SelectedDm is null)
@@ -149,6 +196,9 @@ public class PlayerViewModel : ViewModelBase, IDisposable
         }
     }
 
+    /// <summary>
+    /// Disconnects from the DM, clears the map and fog, and updates status text.
+    /// </summary>
     async Task DisconnectAsync()
     {
         await _clientService.DisconnectAsync();
@@ -158,6 +208,10 @@ public class PlayerViewModel : ViewModelBase, IDisposable
         StatusText = "Disconnected. Searching for DM sessions...";
     }
 
+    /// <summary>
+    /// Initialises the fog service with the new map dimensions and raises <see cref="FogUpdated"/>
+    /// for the full map area so the canvas rebuilds its fog bitmap.
+    /// </summary>
     void OnSessionInfoReceived(object? sender, MapSession session)
     {
         Dispatcher.UIThread.Post(() =>
@@ -168,6 +222,7 @@ public class PlayerViewModel : ViewModelBase, IDisposable
         });
     }
 
+    /// <summary>Decodes the received image bytes into a <see cref="Bitmap"/> and assigns it to <see cref="MapImage"/>.</summary>
     void OnMapImageReceived(object? sender, byte[] imageBytes)
     {
         Dispatcher.UIThread.Post(() =>
@@ -177,6 +232,7 @@ public class PlayerViewModel : ViewModelBase, IDisposable
         });
     }
 
+    /// <summary>Merges the received fog delta into the local mask and raises <see cref="FogUpdated"/> for the changed region.</summary>
     void OnFogDeltaReceived(object? sender, FogDelta delta)
     {
         Dispatcher.UIThread.Post(() =>
@@ -186,6 +242,10 @@ public class PlayerViewModel : ViewModelBase, IDisposable
         });
     }
 
+    /// <summary>
+    /// Replaces the local fog mask entirely with the received one and raises <see cref="FogUpdated"/>
+    /// for the full map area.
+    /// </summary>
     void OnFogFullReceived(object? sender, FogMask mask)
     {
         Dispatcher.UIThread.Post(() =>
@@ -196,6 +256,7 @@ public class PlayerViewModel : ViewModelBase, IDisposable
         });
     }
 
+    /// <summary>Updates connection state and status text when the DM disconnects.</summary>
     void OnDisconnected(object? sender, EventArgs e)
     {
         Dispatcher.UIThread.Post(() =>
@@ -205,6 +266,7 @@ public class PlayerViewModel : ViewModelBase, IDisposable
         });
     }
 
+    /// <inheritdoc/>
     public void Dispose()
     {
         (_discoveryService as IDisposable)?.Dispose();

--- a/DMap/ViewModels/ViewModelBase.cs
+++ b/DMap/ViewModels/ViewModelBase.cs
@@ -2,6 +2,11 @@ using ReactiveUI;
 
 namespace DMap.ViewModels;
 
+/// <summary>
+/// Base class for all ViewModels in the application.
+/// Inherits <see cref="ReactiveObject"/> to provide property-change notification
+/// via <c>this.RaiseAndSetIfChanged</c>.
+/// </summary>
 public abstract class ViewModelBase : ReactiveObject
 {
 }

--- a/DMap/Views/DmView.axaml.cs
+++ b/DMap/Views/DmView.axaml.cs
@@ -14,10 +14,19 @@ using ReactiveUI.Avalonia;
 
 namespace DMap.Views;
 
+/// <summary>
+/// Code-behind for the DM (Dungeon Master) view. Wires the <see cref="MapCanvas"/> events
+/// to the ViewModel, handles fog bitmap updates, and implements the ReactiveUI interactions
+/// for the file picker and the player window.
+/// </summary>
 public partial class DmView : ReactiveUserControl<DmViewModel>
 {
     CompositeDisposable? _activationDisposables;
 
+    /// <summary>
+    /// Initialises the view, wires canvas input events to ViewModel methods, and sets up
+    /// ReactiveUI activation to subscribe to fog updates and handle interactions.
+    /// </summary>
     public DmView()
     {
         InitializeComponent();
@@ -65,12 +74,21 @@ public partial class DmView : ReactiveUserControl<DmViewModel>
         });
     }
 
+    /// <summary>
+    /// Forwards a fog update from the ViewModel to <see cref="MapCanvas.InvalidateFogRegion"/>
+    /// so only the changed bitmap region is redrawn.
+    /// </summary>
     void OnFogUpdated(object? sender, Avalonia.PixelRect dirtyRect)
     {
         var canvas = this.FindControl<MapCanvas>("MapCanvas")!;
         canvas.InvalidateFogRegion(dirtyRect);
     }
 
+    /// <summary>
+    /// Handles the <see cref="DmViewModel.ShowPlayerWindow"/> interaction by creating a new
+    /// top-level window containing a <see cref="PlayerView"/> and disposing the ViewModel when
+    /// the window is closed.
+    /// </summary>
     void HandleShowPlayerWindow(IInteractionContext<PlayerViewModel, Unit> context)
     {
         var playerVm = context.Input;
@@ -86,6 +104,11 @@ public partial class DmView : ReactiveUserControl<DmViewModel>
         context.SetOutput(Unit.Default);
     }
 
+    /// <summary>
+    /// Handles the <see cref="DmViewModel.ShowOpenFileDialog"/> interaction by opening the
+    /// platform file picker filtered to common image formats, returning the chosen local path
+    /// or <see langword="null"/> if the dialog was cancelled.
+    /// </summary>
     async Task HandleOpenFileDialog(IInteractionContext<Unit, string?> context)
     {
         var topLevel = TopLevel.GetTopLevel(this);

--- a/DMap/Views/MainWindow.axaml.cs
+++ b/DMap/Views/MainWindow.axaml.cs
@@ -4,8 +4,13 @@ using ReactiveUI.Avalonia;
 
 namespace DMap.Views;
 
+/// <summary>
+/// The application's root window. Binds to <see cref="MainWindowViewModel"/> and displays
+/// whatever control is set as <see cref="MainWindowViewModel.Content"/>.
+/// </summary>
 public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 {
+    /// <summary>Initialises the window and loads its XAML layout.</summary>
     public MainWindow()
     {
         InitializeComponent();

--- a/DMap/Views/PlayerView.axaml.cs
+++ b/DMap/Views/PlayerView.axaml.cs
@@ -11,10 +11,18 @@ using ReactiveUI.Avalonia;
 
 namespace DMap.Views;
 
+/// <summary>
+/// Code-behind for the player view. Wires the <see cref="MapCanvas"/> to the
+/// <see cref="PlayerViewModel"/> so that fog updates from the DM are reflected in the canvas.
+/// </summary>
 public partial class PlayerView : ReactiveUserControl<PlayerViewModel>
 {
     CompositeDisposable? _activationDisposables;
 
+    /// <summary>
+    /// Initialises the view and sets up ReactiveUI activation to subscribe to fog mask
+    /// changes and fog update events from the ViewModel.
+    /// </summary>
     public PlayerView()
     {
         InitializeComponent();
@@ -47,6 +55,10 @@ public partial class PlayerView : ReactiveUserControl<PlayerViewModel>
         });
     }
 
+    /// <summary>
+    /// Forwards a fog update from the ViewModel to <see cref="MapCanvas.InvalidateFogRegion"/>
+    /// so only the changed bitmap region is redrawn.
+    /// </summary>
     void OnFogUpdated(object? sender, Avalonia.PixelRect dirtyRect)
     {
         var canvas = this.FindControl<MapCanvas>("MapCanvas")!;


### PR DESCRIPTION
## Summary
This PR adds complete XML documentation comments (`///`) to all public types, methods, properties, and events throughout the codebase. This improves IDE IntelliSense, enables generated API documentation, and makes the codebase more maintainable by explicitly documenting the purpose and behavior of each public API surface.

## Key Changes

- **ViewModels**: Added detailed documentation to `DmViewModel`, `PlayerViewModel`, and `MainWindowViewModel` explaining their responsibilities, key properties, and command purposes
- **Controls**: Documented `MapCanvas` control and its event argument types (`BrushStrokeEventArgs`, `ShapeStrokeEventArgs`), including all styled properties and their semantics
- **Services**: Added documentation to all service interfaces and implementations:
  - Networking services (`IDmHostService`, `IPlayerClientService`, `IDiscoveryService`, `DiscoveryService`, `DmHostService`, `PlayerClientService`)
  - Fog management (`IFogMaskService`, `FogMaskService`)
  - History/undo-redo (`IUndoRedoService`, `UndoRedoService`)
  - Brush implementations (`IBrush`, `CircleBrush`, `SquareBrush`, `DiamondBrush`, `BrushHelper`)
  - Protocol definitions (`MessageType`, `FogDelta`)
- **Models**: Documented all data models including `FogMask`, `MapSession`, `BrushSettings`, `IFogCommand`, `FogDeltaCommand`, and enums (`ToolType`, `BrushShape`, `ShapeType`)
- **Converters**: Added documentation to value converter classes (`EnumSvgConverter<T>`, `ToolTypeIconConverter`, `BrushShapeIconConverter`, `ShapeTypeIconConverter`, `SvgIconLoader`)
- **Views & Code-behind**: Documented view classes (`DmView`, `PlayerView`, `MainWindow`) and their initialization logic
- **Application**: Added documentation to `App` and `Program` entry points

## Notable Implementation Details

- Documentation includes parameter descriptions for methods and properties
- Cross-references use `<see cref="..."/>` and `<see langword="..."/>` tags for proper linking
- Complex properties with side effects (e.g., `FogOpacity` raising `FogOpacityPercent` notifications) are explicitly documented
- Event documentation clarifies when events are raised and what their arguments contain
- Service interface documentation explains the threading model (e.g., network callbacks marshalled to UI thread)
- Enum values are individually documented to explain their distinct behaviors

https://claude.ai/code/session_01Tp27rdLbh1mQRwc1ShQHpN