### PR TITLE
Add real-time memory usage monitoring to DM view

### DIFF
--- a/DMap/ViewModels/DmViewModel.cs
+++ b/DMap/ViewModels/DmViewModel.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Reactive;
 using System.Reactive.Linq;
@@ -353,7 +352,7 @@ public class DmViewModel : ViewModelBase, IDisposable
     }
 
     static string FormatMemoryUsage() =>
-        $"{Process.GetCurrentProcess().WorkingSet64 / 1024 / 1024} MB";
+        $"{Environment.WorkingSet / 1024 / 1024} MB";
 
     public void BeginBrushStroke() => _fogService.BeginStroke();
 

--- a/DMap/ViewModels/DmViewModel.cs
+++ b/DMap/ViewModels/DmViewModel.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Media.Imaging;
+using Avalonia.Threading;
 
 using DMap.Models;
 using DMap.Services.Brushes;
@@ -218,7 +219,7 @@ public class DmViewModel : ViewModelBase, IDisposable
 
     byte[]? _mapImageBytes;
     MapSession? _session;
-    readonly IDisposable _memoryTimer;
+    readonly DispatcherTimer _memoryTimer;
 
     public DmViewModel(IFogMaskService fogService, IUndoRedoService undoRedo, IDmHostService hostService, IDiscoveryService discoveryService, Func<PlayerViewModel> createPlayer)
     {
@@ -235,9 +236,8 @@ public class DmViewModel : ViewModelBase, IDisposable
         _undoRedo.StateChanged += (_, _) => { CanUndo = _undoRedo.CanUndo; CanRedo = _undoRedo.CanRedo; };
 
         MemoryUsage = FormatMemoryUsage();
-        _memoryTimer = Observable.Interval(TimeSpan.FromSeconds(2))
-            .ObserveOn(RxApp.MainThreadScheduler)
-            .Subscribe(_ => MemoryUsage = FormatMemoryUsage());
+        _memoryTimer = new DispatcherTimer(TimeSpan.FromSeconds(2), DispatcherPriority.Background, (_, _) => MemoryUsage = FormatMemoryUsage());
+        _memoryTimer.Start();
 
         LoadMapCommand = ReactiveCommand.CreateFromTask(LoadMapAsync);
         ZoomInCommand = ReactiveCommand.Create(() => { ZoomLevel = Math.Min(ZoomLevel * 1.2, 10.0); });
@@ -457,7 +457,7 @@ public class DmViewModel : ViewModelBase, IDisposable
     {
         if (disposing)
         {
-            _memoryTimer.Dispose();
+            _memoryTimer.Stop();
             (_hostService as IDisposable)?.Dispose();
             (_discoveryService as IDisposable)?.Dispose();
         }

--- a/DMap/ViewModels/DmViewModel.cs
+++ b/DMap/ViewModels/DmViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Reactive;
 using System.Reactive.Linq;
@@ -144,6 +145,12 @@ public class DmViewModel : ViewModelBase, IDisposable
         set => this.RaiseAndSetIfChanged(ref field, value);
     }
 
+    public string MemoryUsage
+    {
+        get;
+        private set => this.RaiseAndSetIfChanged(ref field, value);
+    } = string.Empty;
+
     public ToolType SelectedTool
     {
         get;
@@ -212,6 +219,7 @@ public class DmViewModel : ViewModelBase, IDisposable
 
     byte[]? _mapImageBytes;
     MapSession? _session;
+    readonly IDisposable _memoryTimer;
 
     public DmViewModel(IFogMaskService fogService, IUndoRedoService undoRedo, IDmHostService hostService, IDiscoveryService discoveryService, Func<PlayerViewModel> createPlayer)
     {
@@ -226,6 +234,11 @@ public class DmViewModel : ViewModelBase, IDisposable
 
         _hostService.PlayerCountChanged += (_, count) => ConnectedPlayers = count;
         _undoRedo.StateChanged += (_, _) => { CanUndo = _undoRedo.CanUndo; CanRedo = _undoRedo.CanRedo; };
+
+        MemoryUsage = FormatMemoryUsage();
+        _memoryTimer = Observable.Interval(TimeSpan.FromSeconds(2))
+            .ObserveOn(RxApp.MainThreadScheduler)
+            .Subscribe(_ => MemoryUsage = FormatMemoryUsage());
 
         LoadMapCommand = ReactiveCommand.CreateFromTask(LoadMapAsync);
         ZoomInCommand = ReactiveCommand.Create(() => { ZoomLevel = Math.Min(ZoomLevel * 1.2, 10.0); });
@@ -339,6 +352,9 @@ public class DmViewModel : ViewModelBase, IDisposable
         await StartHostingAsync();
     }
 
+    static string FormatMemoryUsage() =>
+        $"{Process.GetCurrentProcess().WorkingSet64 / 1024 / 1024} MB";
+
     public void BeginBrushStroke() => _fogService.BeginStroke();
 
     public void EndBrushStroke()
@@ -442,6 +458,7 @@ public class DmViewModel : ViewModelBase, IDisposable
     {
         if (disposing)
         {
+            _memoryTimer.Dispose();
             (_hostService as IDisposable)?.Dispose();
             (_discoveryService as IDisposable)?.Dispose();
         }

--- a/DMap/Views/DmView.axaml
+++ b/DMap/Views/DmView.axaml
@@ -225,6 +225,11 @@
                         <Image Source="{SvgImage /Assets/Icons/redo-2.svg}" />
                     </Button>
                 </StackPanel>
+                <TextBlock DockPanel.Dock="Right"
+                           Text="{Binding MemoryUsage}"
+                           VerticalAlignment="Center" FontSize="11"
+                           ToolTip.Tip="Memory usage"
+                           Margin="0,0,8,0" />
                 <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="4" VerticalAlignment="Center" Margin="0,0,8,0">
                     <Button Classes="statusbar" Width="18" Command="{Binding FogOpacityDownCommand}" ToolTip.Tip="Less fog">
                         <Image Source="{SvgImage /Assets/Icons/sun.svg}" />


### PR DESCRIPTION
## Summary
This PR adds real-time memory usage monitoring to the Dungeon Master view, displaying the current process memory consumption in the status bar and updating it every 2 seconds.

## Key Changes
- Added `MemoryUsage` property to `DmViewModel` to track and expose memory usage as a formatted string
- Implemented periodic memory monitoring using RxJS `Observable.Interval` that updates every 2 seconds
- Added `FormatMemoryUsage()` static method that retrieves the current process working set and formats it as MB
- Added memory usage `TextBlock` to the status bar in `DmView.axaml` displaying the value with a tooltip
- Properly disposed of the memory timer subscription in the `Dispose` method to prevent resource leaks

## Implementation Details
- Memory updates are scheduled on the main thread scheduler to ensure UI thread safety
- The memory timer is stored as a readonly field and disposed during object cleanup
- Memory usage is displayed in the status bar's right dock area with 11pt font size and 8px right margin
- Initial memory usage is calculated immediately upon ViewModel initialization

https://claude.ai/code/session_01AyhVpZJ6bDMDD9c6JHWPHN