### PR TITLE
Reveal player disconnect menu on top hover

### DIFF
--- a/DMap/Views/PlayerView.axaml
+++ b/DMap/Views/PlayerView.axaml
@@ -8,6 +8,13 @@
              x:Class="DMap.Views.PlayerView"
              x:DataType="vm:PlayerViewModel">
 
+    <UserControl.Styles>
+        <Style Selector="Border#TopHoverArea:pointerover StackPanel#TopMenu">
+            <Setter Property="Opacity" Value="1" />
+            <Setter Property="IsHitTestVisible" Value="True" />
+        </Style>
+    </UserControl.Styles>
+
     <Panel>
         <!-- Discovery / Connection Panel (shown when not connected) -->
         <StackPanel IsVisible="{Binding !IsConnected}"
@@ -36,16 +43,27 @@
         </StackPanel>
 
         <!-- Map Display (shown when connected) -->
-        <DockPanel IsVisible="{Binding IsConnected}">
-            <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Spacing="8"
-                        Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
-                        Height="40">
-                <TextBlock Text="{Binding StatusText}" VerticalAlignment="Center" Margin="12,0" />
-                <Button Content="Disconnect" Command="{Binding DisconnectCommand}"
-                        Margin="8,4" VerticalAlignment="Center" />
-            </StackPanel>
+        <Grid IsVisible="{Binding IsConnected}" RowDefinitions="Auto,*">
+            <Border x:Name="TopHoverArea"
+                    Grid.Row="0"
+                    Background="Transparent"
+                    Height="48"
+                    VerticalAlignment="Top">
+                <StackPanel x:Name="TopMenu"
+                            Orientation="Horizontal"
+                            Spacing="8"
+                            Height="40"
+                            Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}"
+                            Opacity="0"
+                            IsHitTestVisible="False">
+                    <TextBlock Text="{Binding StatusText}" VerticalAlignment="Center" Margin="12,0" />
+                    <Button Content="Disconnect" Command="{Binding DisconnectCommand}"
+                            Margin="8,4" VerticalAlignment="Center" />
+                </StackPanel>
+            </Border>
 
-            <controls:MapCanvas x:Name="MapCanvas"
+            <controls:MapCanvas Grid.Row="1"
+                                x:Name="MapCanvas"
                                 MapImage="{Binding MapImage}"
                                 FogMask="{Binding FogMask}"
                                 IsDmMode="False"
@@ -53,7 +71,7 @@
                                 FogType="{Binding FogType}"
                                 FogColor="{Binding FogColor}"
                                 FogSeed="{Binding FogSeed}" />
-        </DockPanel>
+        </Grid>
     </Panel>
 
 </UserControl>


### PR DESCRIPTION
### Motivation
- The top disconnect/status bar was intrusive during play and should be hidden to improve map visibility. 
- The menu should remain accessible but only appear when the user intentionally aims for the top of the screen. 

### Description
- Replaced the always-visible connected header with a `Grid` layout and a transparent hover zone named `TopHoverArea` that sits above the map. 
- Moved the status text and `Disconnect` button into a `StackPanel` named `TopMenu` that starts with `Opacity="0"` and `IsHitTestVisible="False"` so it doesn't block interaction. 
- Added a style `Selector="Border#TopHoverArea:pointerover StackPanel#TopMenu"` in `UserControl.Styles` that sets `Opacity` to `1` and `IsHitTestVisible` to `True` when the pointer is over the top area. 
- Changes made in `DMap/Views/PlayerView.axaml` to keep `MapCanvas` rendering unchanged while connected. 

### Testing
- Attempted to run `dotnet build dmap.slnx`, but the build could not be executed because `dotnet` is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50c34431883299c589482c1b6704c)