### PR TITLE
Add configurable DM grid tool with network-synced grid settings

### DIFF
--- a/DMap/Assets/Icons/grid-2x2.svg
+++ b/DMap/Assets/Icons/grid-2x2.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-grid2x2-icon lucide-grid-2x2"><path d="M12 3v18"/><path d="M3 12h18"/><rect x="3" y="3" width="18" height="18" rx="2"/></svg>

--- a/DMap/Controls/MapCanvas.cs
+++ b/DMap/Controls/MapCanvas.cs
@@ -158,7 +158,6 @@ public class MapCanvas : Control
     public static readonly StyledProperty<bool> IsGridVisibleProperty = AvaloniaProperty.Register<MapCanvas, bool>(nameof(IsGridVisible));
     public static readonly StyledProperty<double> GridSquareSizeProperty = AvaloniaProperty.Register<MapCanvas, double>(nameof(GridSquareSize), 70);
     public static readonly StyledProperty<double> GridLineWidthProperty = AvaloniaProperty.Register<MapCanvas, double>(nameof(GridLineWidth), 1);
-    public static readonly StyledProperty<double> GridLineSoftnessProperty = AvaloniaProperty.Register<MapCanvas, double>(nameof(GridLineSoftness));
     public static readonly StyledProperty<double> GridOpacityProperty = AvaloniaProperty.Register<MapCanvas, double>(nameof(GridOpacity), 0.65);
     public static readonly StyledProperty<Color> GridColorProperty = AvaloniaProperty.Register<MapCanvas, Color>(nameof(GridColor), Colors.White);
     public static readonly StyledProperty<double> GridOffsetXProperty = AvaloniaProperty.Register<MapCanvas, double>(nameof(GridOffsetX));
@@ -364,7 +363,6 @@ public class MapCanvas : Control
     public bool IsGridVisible { get => GetValue(IsGridVisibleProperty); set => SetValue(IsGridVisibleProperty, value); }
     public double GridSquareSize { get => GetValue(GridSquareSizeProperty); set => SetValue(GridSquareSizeProperty, value); }
     public double GridLineWidth { get => GetValue(GridLineWidthProperty); set => SetValue(GridLineWidthProperty, value); }
-    public double GridLineSoftness { get => GetValue(GridLineSoftnessProperty); set => SetValue(GridLineSoftnessProperty, value); }
     public double GridOpacity { get => GetValue(GridOpacityProperty); set => SetValue(GridOpacityProperty, value); }
     public Color GridColor { get => GetValue(GridColorProperty); set => SetValue(GridColorProperty, value); }
     public double GridOffsetX { get => GetValue(GridOffsetXProperty); set => SetValue(GridOffsetXProperty, value); }
@@ -430,7 +428,7 @@ public class MapCanvas : Control
             BrushDiameterProperty, ActiveToolProperty, BrushShapeProperty,
             ShapeTypeProperty, ShapeCornerRadiusProperty, CursorTypeProperty, CursorSizeProperty, CursorMapXProperty,
             CursorMapYProperty, IsCursorVisibleProperty, ShowMapProperty,
-            IsGridVisibleProperty, GridSquareSizeProperty, GridLineWidthProperty, GridLineSoftnessProperty, GridOpacityProperty, GridColorProperty, GridOffsetXProperty, GridOffsetYProperty,
+            IsGridVisibleProperty, GridSquareSizeProperty, GridLineWidthProperty, GridOpacityProperty, GridColorProperty, GridOffsetXProperty, GridOffsetYProperty,
             FogTypeProperty, FogColorProperty, FogSeedProperty);
     }
 
@@ -614,7 +612,6 @@ public class MapCanvas : Control
             return;
 
         var lineBrush = new SolidColorBrush(GridColor, Math.Clamp(GridOpacity, 0, 1));
-        var soft = Math.Clamp(GridLineSoftness, 0, 1);
         var pen = new Pen(lineBrush, Math.Max(0.1, GridLineWidth));
         var square = GridSquareSize;
         var ox = GridOffsetX * square;
@@ -625,15 +622,6 @@ public class MapCanvas : Control
 
         for (double y = oy; y <= imageRect.Height; y += square)
             context.DrawLine(pen, new Point(0, y), new Point(imageRect.Width, y));
-
-        if (soft > 0)
-        {
-            var blurPen = new Pen(new SolidColorBrush(GridColor, GridOpacity * soft * 0.35), Math.Max(0.1, GridLineWidth * (1 + soft * 2)));
-            for (double x = ox; x <= imageRect.Width; x += square)
-                context.DrawLine(blurPen, new Point(x, 0), new Point(x, imageRect.Height));
-            for (double y = oy; y <= imageRect.Height; y += square)
-                context.DrawLine(blurPen, new Point(0, y), new Point(imageRect.Width, y));
-        }
     }
 
     /// <summary>

--- a/DMap/Controls/MapCanvas.cs
+++ b/DMap/Controls/MapCanvas.cs
@@ -155,6 +155,15 @@ public class MapCanvas : Control
     public static readonly StyledProperty<bool> ShowMapProperty =
         AvaloniaProperty.Register<MapCanvas, bool>(nameof(ShowMap), true);
 
+    public static readonly StyledProperty<bool> IsGridVisibleProperty = AvaloniaProperty.Register<MapCanvas, bool>(nameof(IsGridVisible));
+    public static readonly StyledProperty<double> GridSquareSizeProperty = AvaloniaProperty.Register<MapCanvas, double>(nameof(GridSquareSize), 70);
+    public static readonly StyledProperty<double> GridLineWidthProperty = AvaloniaProperty.Register<MapCanvas, double>(nameof(GridLineWidth), 1);
+    public static readonly StyledProperty<double> GridLineSoftnessProperty = AvaloniaProperty.Register<MapCanvas, double>(nameof(GridLineSoftness));
+    public static readonly StyledProperty<double> GridOpacityProperty = AvaloniaProperty.Register<MapCanvas, double>(nameof(GridOpacity), 0.65);
+    public static readonly StyledProperty<Color> GridColorProperty = AvaloniaProperty.Register<MapCanvas, Color>(nameof(GridColor), Colors.White);
+    public static readonly StyledProperty<double> GridOffsetXProperty = AvaloniaProperty.Register<MapCanvas, double>(nameof(GridOffsetX));
+    public static readonly StyledProperty<double> GridOffsetYProperty = AvaloniaProperty.Register<MapCanvas, double>(nameof(GridOffsetY));
+
     /// <summary>The map background image, or <see langword="null"/> when no map is loaded.</summary>
     public Bitmap? MapImage
     {
@@ -352,6 +361,15 @@ public class MapCanvas : Control
         set => SetValue(ShowMapProperty, value);
     }
 
+    public bool IsGridVisible { get => GetValue(IsGridVisibleProperty); set => SetValue(IsGridVisibleProperty, value); }
+    public double GridSquareSize { get => GetValue(GridSquareSizeProperty); set => SetValue(GridSquareSizeProperty, value); }
+    public double GridLineWidth { get => GetValue(GridLineWidthProperty); set => SetValue(GridLineWidthProperty, value); }
+    public double GridLineSoftness { get => GetValue(GridLineSoftnessProperty); set => SetValue(GridLineSoftnessProperty, value); }
+    public double GridOpacity { get => GetValue(GridOpacityProperty); set => SetValue(GridOpacityProperty, value); }
+    public Color GridColor { get => GetValue(GridColorProperty); set => SetValue(GridColorProperty, value); }
+    public double GridOffsetX { get => GetValue(GridOffsetXProperty); set => SetValue(GridOffsetXProperty, value); }
+    public double GridOffsetY { get => GetValue(GridOffsetYProperty); set => SetValue(GridOffsetYProperty, value); }
+
     /// <summary>Raised when the user presses the pointer to begin a brush stroke.</summary>
     public event EventHandler? BrushStrokeStarted;
 
@@ -412,6 +430,7 @@ public class MapCanvas : Control
             BrushDiameterProperty, ActiveToolProperty, BrushShapeProperty,
             ShapeTypeProperty, ShapeCornerRadiusProperty, CursorTypeProperty, CursorSizeProperty, CursorMapXProperty,
             CursorMapYProperty, IsCursorVisibleProperty, ShowMapProperty,
+            IsGridVisibleProperty, GridSquareSizeProperty, GridLineWidthProperty, GridLineSoftnessProperty, GridOpacityProperty, GridColorProperty, GridOffsetXProperty, GridOffsetYProperty,
             FogTypeProperty, FogColorProperty, FogSeedProperty);
     }
 
@@ -556,6 +575,8 @@ public class MapCanvas : Control
             else
                 context.FillRectangle(Brushes.White, imageRect);
 
+            RenderGrid(context, imageRect);
+
             if (_fogBitmapController.Bitmap != null)
             {
                 var fogRect = new Rect(0, 0, _fogBitmapController.Bitmap.Size.Width, _fogBitmapController.Bitmap.Size.Height);
@@ -585,6 +606,34 @@ public class MapCanvas : Control
         var x = mapX * ZoomLevel + OffsetX - size / 2.0;
         var y = mapY * ZoomLevel + OffsetY - size / 2.0;
         context.DrawImage(icon, new Rect(x, y, size, size));
+    }
+
+    void RenderGrid(DrawingContext context, Rect imageRect)
+    {
+        if (!IsGridVisible || GridSquareSize <= 1 || GridOpacity <= 0 || GridLineWidth <= 0)
+            return;
+
+        var lineBrush = new SolidColorBrush(GridColor, Math.Clamp(GridOpacity, 0, 1));
+        var soft = Math.Clamp(GridLineSoftness, 0, 1);
+        var pen = new Pen(lineBrush, Math.Max(0.1, GridLineWidth));
+        var square = GridSquareSize;
+        var ox = GridOffsetX * square;
+        var oy = GridOffsetY * square;
+
+        for (double x = ox; x <= imageRect.Width; x += square)
+            context.DrawLine(pen, new Point(x, 0), new Point(x, imageRect.Height));
+
+        for (double y = oy; y <= imageRect.Height; y += square)
+            context.DrawLine(pen, new Point(0, y), new Point(imageRect.Width, y));
+
+        if (soft > 0)
+        {
+            var blurPen = new Pen(new SolidColorBrush(GridColor, GridOpacity * soft * 0.35), Math.Max(0.1, GridLineWidth * (1 + soft * 2)));
+            for (double x = ox; x <= imageRect.Width; x += square)
+                context.DrawLine(blurPen, new Point(x, 0), new Point(x, imageRect.Height));
+            for (double y = oy; y <= imageRect.Height; y += square)
+                context.DrawLine(blurPen, new Point(0, y), new Point(imageRect.Width, y));
+        }
     }
 
     /// <summary>

--- a/DMap/Controls/MapCanvas.cs
+++ b/DMap/Controls/MapCanvas.cs
@@ -617,11 +617,14 @@ public class MapCanvas : Control
         var ox = GridOffsetX * square;
         var oy = GridOffsetY * square;
 
-        for (double x = ox; x <= imageRect.Width; x += square)
-            context.DrawLine(pen, new Point(x, 0), new Point(x, imageRect.Height));
+        using (context.PushClip(imageRect))
+        {
+            for (double x = ox; x <= imageRect.Width; x += square)
+                context.DrawLine(pen, new Point(x, 0), new Point(x, imageRect.Height));
 
-        for (double y = oy; y <= imageRect.Height; y += square)
-            context.DrawLine(pen, new Point(0, y), new Point(imageRect.Width, y));
+            for (double y = oy; y <= imageRect.Height; y += square)
+                context.DrawLine(pen, new Point(0, y), new Point(imageRect.Width, y));
+        }
     }
 
     /// <summary>

--- a/DMap/Models/ToolType.cs
+++ b/DMap/Models/ToolType.cs
@@ -19,4 +19,7 @@ public enum ToolType
 
     /// <summary>Player-visible map cursor used as a pointer or marker. Does not modify the fog mask.</summary>
     Cursor,
+
+    /// <summary>Grid overlay settings (visibility, size, style, and offset). Does not modify the fog mask.</summary>
+    Grid,
 }

--- a/DMap/Protocol/GridSettingsPayload.cs
+++ b/DMap/Protocol/GridSettingsPayload.cs
@@ -13,7 +13,6 @@ public sealed class GridSettingsPayload : IPayload
     public bool IsVisible { get; init; }
     public double SquareSize { get; init; }
     public double LineWidth { get; init; }
-    public double LineSoftness { get; init; }
     public double Opacity { get; init; }
     public byte R { get; init; }
     public byte G { get; init; }
@@ -30,7 +29,6 @@ public sealed class GridSettingsPayload : IPayload
         writer.Write(IsVisible);
         writer.Write(SquareSize);
         writer.Write(LineWidth);
-        writer.Write(LineSoftness);
         writer.Write(Opacity);
         writer.Write(R);
         writer.Write(G);
@@ -49,7 +47,6 @@ public sealed class GridSettingsPayload : IPayload
             IsVisible = reader.ReadBoolean(),
             SquareSize = reader.ReadDouble(),
             LineWidth = reader.ReadDouble(),
-            LineSoftness = reader.ReadDouble(),
             Opacity = reader.ReadDouble(),
             R = reader.ReadByte(),
             G = reader.ReadByte(),

--- a/DMap/Protocol/GridSettingsPayload.cs
+++ b/DMap/Protocol/GridSettingsPayload.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+
+using Avalonia.Media;
+
+namespace DMap.Protocol;
+
+/// <summary>
+/// Grid overlay settings broadcast by the DM so player canvases can render the same map grid.
+/// </summary>
+public sealed class GridSettingsPayload : IPayload
+{
+    public bool IsVisible { get; init; }
+    public double SquareSize { get; init; }
+    public double LineWidth { get; init; }
+    public double LineSoftness { get; init; }
+    public double Opacity { get; init; }
+    public byte R { get; init; }
+    public byte G { get; init; }
+    public byte B { get; init; }
+    public double OffsetX { get; init; }
+    public double OffsetY { get; init; }
+
+    public Color Color => Color.FromRgb(R, G, B);
+
+    public byte[] Serialize()
+    {
+        using var ms = new MemoryStream();
+        using var writer = new BinaryWriter(ms);
+        writer.Write(IsVisible);
+        writer.Write(SquareSize);
+        writer.Write(LineWidth);
+        writer.Write(LineSoftness);
+        writer.Write(Opacity);
+        writer.Write(R);
+        writer.Write(G);
+        writer.Write(B);
+        writer.Write(OffsetX);
+        writer.Write(OffsetY);
+        return ms.ToArray();
+    }
+
+    public static GridSettingsPayload Deserialize(byte[] bytes)
+    {
+        using var ms = new MemoryStream(bytes);
+        using var reader = new BinaryReader(ms);
+        return new GridSettingsPayload
+        {
+            IsVisible = reader.ReadBoolean(),
+            SquareSize = reader.ReadDouble(),
+            LineWidth = reader.ReadDouble(),
+            LineSoftness = reader.ReadDouble(),
+            Opacity = reader.ReadDouble(),
+            R = reader.ReadByte(),
+            G = reader.ReadByte(),
+            B = reader.ReadByte(),
+            OffsetX = reader.ReadDouble(),
+            OffsetY = reader.ReadDouble(),
+        };
+    }
+}

--- a/DMap/Protocol/GridSettingsPayload.cs
+++ b/DMap/Protocol/GridSettingsPayload.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 
 using Avalonia.Media;

--- a/DMap/Protocol/MessageType.cs
+++ b/DMap/Protocol/MessageType.cs
@@ -39,4 +39,9 @@ public enum MessageType
     /// Player-visible cursor state broadcast from the DM to players.
     /// </summary>
     Cursor = 7,
+
+    /// <summary>
+    /// Grid overlay settings broadcast from the DM to players.
+    /// </summary>
+    GridSettings = 8,
 }

--- a/DMap/Services/Networking/DmHostService.cs
+++ b/DMap/Services/Networking/DmHostService.cs
@@ -327,6 +327,18 @@ public sealed class DmHostService : IDmHostService
     }
 
     /// <inheritdoc/>
+    public Task SendGridSettingsAsync(GridSettingsPayload settings, CancellationToken ct)
+    {
+        var payload = settings.Serialize();
+        lock (_clientsLock)
+        {
+            _pendingGridSettings = payload;
+        }
+
+        return BroadcastAsync(MessageType.GridSettings, payload, ct);
+    }
+
+    /// <inheritdoc/>
     public Task SendFogFullAsync(FogMask mask, CancellationToken ct)
     {
         lock (_clientsLock)

--- a/DMap/Services/Networking/DmHostService.cs
+++ b/DMap/Services/Networking/DmHostService.cs
@@ -93,6 +93,9 @@ public interface IDmHostService : IDisposable
     /// <param name="cursor">Cursor state.</param>
     /// <param name="ct">Cancellation token.</param>
     Task SendCursorAsync(CursorPayload cursor, CancellationToken ct);
+
+    /// <summary>Broadcasts the current grid overlay settings to players and caches them for late joiners.</summary>
+    Task SendGridSettingsAsync(GridSettingsPayload settings, CancellationToken ct);
 }
 
 /// <summary>
@@ -128,6 +131,7 @@ public sealed class DmHostService : IDmHostService
 
     /// <summary>Cached cursor payload sent to new clients on connect, or <see langword="null"/> if never set.</summary>
     byte[]? _pendingCursor;
+    byte[]? _pendingGridSettings;
 
     /// <inheritdoc/>
     public int Port { get; set; }
@@ -190,6 +194,7 @@ public sealed class DmHostService : IDmHostService
             byte[]? pendingFogAppearance;
             byte[]? pendingViewport;
             byte[]? pendingCursor;
+            byte[]? pendingGridSettings;
             lock (_clientsLock)
             {
                 pendingSessionInfo = _pendingSession is not null && _pendingFogMask is not null
@@ -199,6 +204,7 @@ public sealed class DmHostService : IDmHostService
                 pendingFogAppearance = _pendingFogAppearance;
                 pendingViewport = _pendingViewport;
                 pendingCursor = _pendingCursor;
+                pendingGridSettings = _pendingGridSettings;
             }
 
             if (pendingSessionInfo is not null)
@@ -215,6 +221,9 @@ public sealed class DmHostService : IDmHostService
 
             if (pendingCursor is not null)
                 await ProtocolFraming.WriteFrameAsync(stream, MessageType.Cursor, pendingCursor, default);
+
+            if (pendingGridSettings is not null)
+                await ProtocolFraming.WriteFrameAsync(stream, MessageType.GridSettings, pendingGridSettings, default);
 
             // Keep connection alive until cancelled or disconnected
             var buffer = new byte[1];

--- a/DMap/Services/Networking/PlayerClientService.cs
+++ b/DMap/Services/Networking/PlayerClientService.cs
@@ -60,6 +60,9 @@ public interface IPlayerClientService : IDisposable
     /// </summary>
     event EventHandler<CursorPayload>? CursorReceived;
 
+    /// <summary>Raised when a <see cref="MessageType.GridSettings"/> frame is received.</summary>
+    event EventHandler<GridSettingsPayload>? GridSettingsReceived;
+
     /// <summary>
     /// Raised when the connection to the DM is closed, either because the DM disconnected,
     /// the network failed, or <see cref="DisconnectAsync"/> was called.
@@ -110,6 +113,9 @@ public sealed class PlayerClientService : IPlayerClientService
 
     /// <inheritdoc/>
     public event EventHandler<CursorPayload>? CursorReceived;
+
+    /// <inheritdoc/>
+    public event EventHandler<GridSettingsPayload>? GridSettingsReceived;
 
     /// <inheritdoc/>
     public event EventHandler? Disconnected;
@@ -163,6 +169,9 @@ public sealed class PlayerClientService : IPlayerClientService
                         break;
                     case MessageType.Cursor:
                         CursorReceived?.Invoke(this, CursorPayload.Deserialize(payload));
+                        break;
+                    case MessageType.GridSettings:
+                        GridSettingsReceived?.Invoke(this, GridSettingsPayload.Deserialize(payload));
                         break;
                 }
             }

--- a/DMap/ViewModels/DmViewModel.cs
+++ b/DMap/ViewModels/DmViewModel.cs
@@ -282,7 +282,6 @@ public class DmViewModel : ViewModelBase, IDisposable
     public bool IsGridVisible { get; set { this.RaiseAndSetIfChanged(ref field, value); BroadcastGridSettings(); } }
     public double GridSquareSize { get; set { this.RaiseAndSetIfChanged(ref field, value); BroadcastGridSettings(); } } = 70;
     public double GridLineWidth { get; set { this.RaiseAndSetIfChanged(ref field, value); BroadcastGridSettings(); } } = 1;
-    public double GridLineSoftness { get; set { this.RaiseAndSetIfChanged(ref field, value); BroadcastGridSettings(); } }
     public double GridOpacity { get; set { this.RaiseAndSetIfChanged(ref field, value); BroadcastGridSettings(); } } = 0.65;
     public Color GridColor { get; set { this.RaiseAndSetIfChanged(ref field, value); BroadcastGridSettings(); } } = Colors.White;
     public double GridOffsetX { get; set { this.RaiseAndSetIfChanged(ref field, value); BroadcastGridSettings(); } }
@@ -753,7 +752,6 @@ public class DmViewModel : ViewModelBase, IDisposable
             IsVisible = IsGridVisible,
             SquareSize = GridSquareSize,
             LineWidth = GridLineWidth,
-            LineSoftness = GridLineSoftness,
             Opacity = GridOpacity,
             R = GridColor.R,
             G = GridColor.G,

--- a/DMap/ViewModels/DmViewModel.cs
+++ b/DMap/ViewModels/DmViewModel.cs
@@ -156,6 +156,7 @@ public class DmViewModel : ViewModelBase, IDisposable
             this.RaisePropertyChanged(nameof(IsPanSelected));
             this.RaisePropertyChanged(nameof(IsFogSelected));
             this.RaisePropertyChanged(nameof(IsCursorSelected));
+            this.RaisePropertyChanged(nameof(IsGridSelected));
         }
     }
 
@@ -173,6 +174,7 @@ public class DmViewModel : ViewModelBase, IDisposable
 
     /// <summary><see langword="true"/> when the Cursor tool is active.</summary>
     public bool IsCursorSelected => SelectedTool == ToolType.Cursor;
+    public bool IsGridSelected => SelectedTool == ToolType.Grid;
 
     /// <summary>The brush shape (circle, square, or diamond) used when the Brush tool is active.</summary>
     public BrushShape SelectedBrushShape
@@ -277,6 +279,15 @@ public class DmViewModel : ViewModelBase, IDisposable
     /// <summary>All available cursor icon types, used to populate the cursor selector.</summary>
     public IReadOnlyList<CursorType> CursorTypes { get; } = Enum.GetValues<CursorType>();
 
+    public bool IsGridVisible { get; set { this.RaiseAndSetIfChanged(ref field, value); BroadcastGridSettings(); } }
+    public double GridSquareSize { get; set { this.RaiseAndSetIfChanged(ref field, value); BroadcastGridSettings(); } } = 70;
+    public double GridLineWidth { get; set { this.RaiseAndSetIfChanged(ref field, value); BroadcastGridSettings(); } } = 1;
+    public double GridLineSoftness { get; set { this.RaiseAndSetIfChanged(ref field, value); BroadcastGridSettings(); } }
+    public double GridOpacity { get; set { this.RaiseAndSetIfChanged(ref field, value); BroadcastGridSettings(); } } = 0.65;
+    public Color GridColor { get; set { this.RaiseAndSetIfChanged(ref field, value); BroadcastGridSettings(); } } = Colors.White;
+    public double GridOffsetX { get; set { this.RaiseAndSetIfChanged(ref field, value); BroadcastGridSettings(); } }
+    public double GridOffsetY { get; set { this.RaiseAndSetIfChanged(ref field, value); BroadcastGridSettings(); } }
+
     /// <summary><see langword="true"/> when at least one operation is available to undo.</summary>
     public bool CanUndo
     {
@@ -308,6 +319,7 @@ public class DmViewModel : ViewModelBase, IDisposable
 
     /// <summary>Activates the Cursor tool.</summary>
     public ReactiveCommand<Unit, Unit> SelectCursorCommand { get; }
+    public ReactiveCommand<Unit, Unit> SelectGridCommand { get; }
 
     /// <summary>Sets all fog mask pixels to 255 (fully revealed) and pushes an undo entry.</summary>
     public ReactiveCommand<Unit, Unit> RevealAllCommand { get; }
@@ -433,6 +445,7 @@ public class DmViewModel : ViewModelBase, IDisposable
         SelectPanCommand = ReactiveCommand.Create(() => { SelectedTool = ToolType.Pan; });
         SelectFogCommand = ReactiveCommand.Create(() => { SelectedTool = ToolType.Fog; });
         SelectCursorCommand = ReactiveCommand.Create(() => { SelectedTool = ToolType.Cursor; });
+        SelectGridCommand = ReactiveCommand.Create(() => { SelectedTool = ToolType.Grid; });
 
         var mapLoaded = this.WhenAnyValue(x => x.IsMapLoaded);
         RevealAllCommand = ReactiveCommand.Create(ExecuteRevealAll, mapLoaded);
@@ -565,6 +578,7 @@ public class DmViewModel : ViewModelBase, IDisposable
 
         await StartHostingAsync();
         BroadcastFogAppearance();
+        BroadcastGridSettings();
         QueueViewportBroadcast();
     }
 
@@ -728,6 +742,29 @@ public class DmViewModel : ViewModelBase, IDisposable
     /// to all connected players. Called whenever <see cref="SelectedFogType"/> or <see cref="FogColor"/>
     /// changes, and once per map load. Skipped before the host starts (no session yet).
     /// </summary>
+
+    void BroadcastGridSettings()
+    {
+        if (IsUpdatesPaused)
+            return;
+
+        var payload = new GridSettingsPayload
+        {
+            IsVisible = IsGridVisible,
+            SquareSize = GridSquareSize,
+            LineWidth = GridLineWidth,
+            LineSoftness = GridLineSoftness,
+            Opacity = GridOpacity,
+            R = GridColor.R,
+            G = GridColor.G,
+            B = GridColor.B,
+            OffsetX = GridOffsetX,
+            OffsetY = GridOffsetY,
+        };
+
+        _ = _hostService.SendGridSettingsAsync(payload, default);
+    }
+
     void BroadcastFogAppearance()
     {
         if (_session is null)

--- a/DMap/ViewModels/PlayerViewModel.cs
+++ b/DMap/ViewModels/PlayerViewModel.cs
@@ -154,6 +154,15 @@ public class PlayerViewModel : ViewModelBase, IDisposable
         private set => this.RaiseAndSetIfChanged(ref field, value);
     }
 
+    public bool IsGridVisible { get; private set => this.RaiseAndSetIfChanged(ref field, value); }
+    public double GridSquareSize { get; private set => this.RaiseAndSetIfChanged(ref field, value); } = 70;
+    public double GridLineWidth { get; private set => this.RaiseAndSetIfChanged(ref field, value); } = 1;
+    public double GridLineSoftness { get; private set => this.RaiseAndSetIfChanged(ref field, value); }
+    public double GridOpacity { get; private set => this.RaiseAndSetIfChanged(ref field, value); } = 0.65;
+    public Color GridColor { get; private set => this.RaiseAndSetIfChanged(ref field, value); } = Colors.White;
+    public double GridOffsetX { get; private set => this.RaiseAndSetIfChanged(ref field, value); }
+    public double GridOffsetY { get; private set => this.RaiseAndSetIfChanged(ref field, value); }
+
     /// <summary>Current state of the player window shell.</summary>
     public WindowState WindowState
     {
@@ -199,6 +208,7 @@ public class PlayerViewModel : ViewModelBase, IDisposable
         _clientService.FogAppearanceReceived += OnFogAppearanceReceived;
         _clientService.ViewportReceived += OnViewportReceived;
         _clientService.CursorReceived += OnCursorReceived;
+        _clientService.GridSettingsReceived += OnGridSettingsReceived;
         _clientService.Disconnected += OnDisconnected;
 
         var canConnect = this.WhenAnyValue(
@@ -364,6 +374,21 @@ public class PlayerViewModel : ViewModelBase, IDisposable
     }
 
     /// <summary>Updates connection state and status text when the DM disconnects.</summary>
+    void OnGridSettingsReceived(object? sender, GridSettingsPayload settings)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            IsGridVisible = settings.IsVisible;
+            GridSquareSize = settings.SquareSize;
+            GridLineWidth = settings.LineWidth;
+            GridLineSoftness = settings.LineSoftness;
+            GridOpacity = settings.Opacity;
+            GridColor = settings.Color;
+            GridOffsetX = settings.OffsetX;
+            GridOffsetY = settings.OffsetY;
+        });
+    }
+
     void OnDisconnected(object? sender, EventArgs e)
     {
         Dispatcher.UIThread.Post(() =>

--- a/DMap/ViewModels/PlayerViewModel.cs
+++ b/DMap/ViewModels/PlayerViewModel.cs
@@ -157,7 +157,6 @@ public class PlayerViewModel : ViewModelBase, IDisposable
     public bool IsGridVisible { get; private set => this.RaiseAndSetIfChanged(ref field, value); }
     public double GridSquareSize { get; private set => this.RaiseAndSetIfChanged(ref field, value); } = 70;
     public double GridLineWidth { get; private set => this.RaiseAndSetIfChanged(ref field, value); } = 1;
-    public double GridLineSoftness { get; private set => this.RaiseAndSetIfChanged(ref field, value); }
     public double GridOpacity { get; private set => this.RaiseAndSetIfChanged(ref field, value); } = 0.65;
     public Color GridColor { get; private set => this.RaiseAndSetIfChanged(ref field, value); } = Colors.White;
     public double GridOffsetX { get; private set => this.RaiseAndSetIfChanged(ref field, value); }
@@ -381,7 +380,6 @@ public class PlayerViewModel : ViewModelBase, IDisposable
             IsGridVisible = settings.IsVisible;
             GridSquareSize = settings.SquareSize;
             GridLineWidth = settings.LineWidth;
-            GridLineSoftness = settings.LineSoftness;
             GridOpacity = settings.Opacity;
             GridColor = settings.Color;
             GridOffsetX = settings.OffsetX;

--- a/DMap/Views/DmView.axaml
+++ b/DMap/Views/DmView.axaml
@@ -298,7 +298,6 @@
                             IsGridVisible="{Binding IsGridVisible}"
                             GridSquareSize="{Binding GridSquareSize}"
                             GridLineWidth="{Binding GridLineWidth}"
-                            GridLineSoftness="{Binding GridLineSoftness}"
                             GridOpacity="{Binding GridOpacity}"
                             GridColor="{Binding GridColor}"
                             GridOffsetX="{Binding GridOffsetX}"
@@ -513,8 +512,6 @@
                             <Slider Minimum="8" Maximum="512" Value="{Binding GridSquareSize}" />
                             <TextBlock Text="{Binding GridLineWidth, StringFormat='Line Width: {0:F2}'}" FontWeight="SemiBold" />
                             <Slider Minimum="0.25" Maximum="10" Value="{Binding GridLineWidth}" />
-                            <TextBlock Text="{Binding GridLineSoftness, StringFormat='Softness: {0:F2}'}" FontWeight="SemiBold" />
-                            <Slider Minimum="0" Maximum="1" Value="{Binding GridLineSoftness}" />
                             <TextBlock Text="{Binding GridOpacity, StringFormat='Opacity: {0:F2}'}" FontWeight="SemiBold" />
                             <Slider Minimum="0" Maximum="1" Value="{Binding GridOpacity}" />
                             <TextBlock Text="Grid Color" FontWeight="SemiBold" />

--- a/DMap/Views/DmView.axaml
+++ b/DMap/Views/DmView.axaml
@@ -379,7 +379,7 @@
                                 Classes.toolSelected="{Binding IsGridSelected}"
                                 Command="{Binding SelectGridCommand}"
                                 ToolTip.Tip="Grid">
-                            <Image Source="{SvgImage /Assets/Icons/brick-wall.svg}" />
+                            <Image Source="{SvgImage /Assets/Icons/grid-2x2.svg}" />
                         </Button>
 
                         <!-- Pan tool -->
@@ -507,7 +507,8 @@
                             <ToggleSwitch IsChecked="{Binding ShowCursorOnlyWhilePressed}" />
                         </StackPanel>
                         <StackPanel Spacing="8" MinWidth="200" IsVisible="{Binding IsGridSelected}">
-                            <ToggleSwitch IsChecked="{Binding IsGridVisible}" Content="Grid Visible" />
+                            <TextBlock Text="Grid Visibility" FontWeight="SemiBold" />
+                            <ToggleSwitch IsChecked="{Binding IsGridVisible}" />
                             <TextBlock Text="{Binding GridSquareSize, StringFormat='Square Size: {0:F0}'}" FontWeight="SemiBold" />
                             <Slider Minimum="8" Maximum="512" Value="{Binding GridSquareSize}" />
                             <TextBlock Text="{Binding GridLineWidth, StringFormat='Line Width: {0:F2}'}" FontWeight="SemiBold" />
@@ -517,7 +518,13 @@
                             <TextBlock Text="{Binding GridOpacity, StringFormat='Opacity: {0:F2}'}" FontWeight="SemiBold" />
                             <Slider Minimum="0" Maximum="1" Value="{Binding GridOpacity}" />
                             <TextBlock Text="Grid Color" FontWeight="SemiBold" />
-                            <ColorPicker Color="{Binding GridColor}" IsAlphaVisible="False" IsAlphaEnabled="False" IsColorPreviewVisible="False" />
+                            <Border BorderThickness="2"
+                                    BorderBrush="{StaticResource DMapHighlight}"
+                                    CornerRadius="4"
+                                    Padding="0"
+                                    HorizontalAlignment="Center">
+                                <ColorPicker Color="{Binding GridColor}" IsAlphaVisible="False" IsAlphaEnabled="False" IsColorPreviewVisible="False" />
+                            </Border>
                             <TextBlock Text="{Binding GridOffsetX, StringFormat='Offset X: {0:F2}'}" FontWeight="SemiBold" />
                             <Slider Minimum="0" Maximum="1" Value="{Binding GridOffsetX}" />
                             <TextBlock Text="{Binding GridOffsetY, StringFormat='Offset Y: {0:F2}'}" FontWeight="SemiBold" />

--- a/DMap/Views/DmView.axaml
+++ b/DMap/Views/DmView.axaml
@@ -294,7 +294,15 @@
                             ShapeCornerRadius="{Binding ShapeCornerRadius}"
                             CursorType="{Binding SelectedCursorType}"
                             CursorSize="{Binding CursorSize}"
-                            ShowCursorOnlyWhilePressed="{Binding ShowCursorOnlyWhilePressed}">
+                            ShowCursorOnlyWhilePressed="{Binding ShowCursorOnlyWhilePressed}"
+                            IsGridVisible="{Binding IsGridVisible}"
+                            GridSquareSize="{Binding GridSquareSize}"
+                            GridLineWidth="{Binding GridLineWidth}"
+                            GridLineSoftness="{Binding GridLineSoftness}"
+                            GridOpacity="{Binding GridOpacity}"
+                            GridColor="{Binding GridColor}"
+                            GridOffsetX="{Binding GridOffsetX}"
+                            GridOffsetY="{Binding GridOffsetY}">
             </controls:MapCanvas>
 
             <Panel IsVisible="{Binding IsOverlayVisible}">
@@ -365,6 +373,13 @@
                                 Command="{Binding SelectCursorCommand}"
                                 ToolTip.Tip="Cursor">
                             <Image Source="{SvgImage /Assets/Icons/crosshair.svg}" />
+                        </Button>
+
+                        <Button Classes="toolbox"
+                                Classes.toolSelected="{Binding IsGridSelected}"
+                                Command="{Binding SelectGridCommand}"
+                                ToolTip.Tip="Grid">
+                            <Image Source="{SvgImage /Assets/Icons/brick-wall.svg}" />
                         </Button>
 
                         <!-- Pan tool -->
@@ -490,6 +505,23 @@
                                     HorizontalAlignment="Stretch" />
                             <TextBlock Text="Show Cursor Only While Pressed" FontWeight="SemiBold" />
                             <ToggleSwitch IsChecked="{Binding ShowCursorOnlyWhilePressed}" />
+                        </StackPanel>
+                        <StackPanel Spacing="8" MinWidth="200" IsVisible="{Binding IsGridSelected}">
+                            <ToggleSwitch IsChecked="{Binding IsGridVisible}" Content="Grid Visible" />
+                            <TextBlock Text="{Binding GridSquareSize, StringFormat='Square Size: {0:F0}'}" FontWeight="SemiBold" />
+                            <Slider Minimum="8" Maximum="512" Value="{Binding GridSquareSize}" />
+                            <TextBlock Text="{Binding GridLineWidth, StringFormat='Line Width: {0:F2}'}" FontWeight="SemiBold" />
+                            <Slider Minimum="0.25" Maximum="10" Value="{Binding GridLineWidth}" />
+                            <TextBlock Text="{Binding GridLineSoftness, StringFormat='Softness: {0:F2}'}" FontWeight="SemiBold" />
+                            <Slider Minimum="0" Maximum="1" Value="{Binding GridLineSoftness}" />
+                            <TextBlock Text="{Binding GridOpacity, StringFormat='Opacity: {0:F2}'}" FontWeight="SemiBold" />
+                            <Slider Minimum="0" Maximum="1" Value="{Binding GridOpacity}" />
+                            <TextBlock Text="Grid Color" FontWeight="SemiBold" />
+                            <ColorPicker Color="{Binding GridColor}" IsAlphaVisible="False" IsAlphaEnabled="False" IsColorPreviewVisible="False" />
+                            <TextBlock Text="{Binding GridOffsetX, StringFormat='Offset X: {0:F2}'}" FontWeight="SemiBold" />
+                            <Slider Minimum="0" Maximum="1" Value="{Binding GridOffsetX}" />
+                            <TextBlock Text="{Binding GridOffsetY, StringFormat='Offset Y: {0:F2}'}" FontWeight="SemiBold" />
+                            <Slider Minimum="0" Maximum="1" Value="{Binding GridOffsetY}" />
                         </StackPanel>
                     </Panel>
                 </Border>

--- a/DMap/Views/PlayerView.axaml
+++ b/DMap/Views/PlayerView.axaml
@@ -141,7 +141,15 @@
                                 CursorMapX="{Binding CursorMapX}"
                                 CursorMapY="{Binding CursorMapY}"
                                 IsCursorVisible="{Binding IsCursorVisible}"
-                                IsFogGenerating="{Binding IsFogGenerating, Mode=OneWayToSource}" />
+                                IsFogGenerating="{Binding IsFogGenerating, Mode=OneWayToSource}"
+                                IsGridVisible="{Binding IsGridVisible}"
+                                GridSquareSize="{Binding GridSquareSize}"
+                                GridLineWidth="{Binding GridLineWidth}"
+                                GridLineSoftness="{Binding GridLineSoftness}"
+                                GridOpacity="{Binding GridOpacity}"
+                                GridColor="{Binding GridColor}"
+                                GridOffsetX="{Binding GridOffsetX}"
+                                GridOffsetY="{Binding GridOffsetY}" />
         </DockPanel>
     </Grid>
 

--- a/DMap/Views/PlayerView.axaml
+++ b/DMap/Views/PlayerView.axaml
@@ -145,7 +145,6 @@
                                 IsGridVisible="{Binding IsGridVisible}"
                                 GridSquareSize="{Binding GridSquareSize}"
                                 GridLineWidth="{Binding GridLineWidth}"
-                                GridLineSoftness="{Binding GridLineSoftness}"
                                 GridOpacity="{Binding GridOpacity}"
                                 GridColor="{Binding GridColor}"
                                 GridOffsetX="{Binding GridOffsetX}"

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -35,3 +35,5 @@ Unreleased
 * Choose from multiple fog themes, including colour and textured styles.
 * Open a synced player view that follows DM panning, zooming, and fog edits in real time.
 * Discover DM sessions over LAN and host reliable player connections over TCP.
+
+* Added DM-configurable map grid overlay (visibility, size, line style, opacity, color, and offsets) synchronized to players.

--- a/docs/source/protocol.rst
+++ b/docs/source/protocol.rst
@@ -241,3 +241,8 @@ This payload controls the cursor shown to players.
    * - Visible
      - 1
      - 1 if the cursor should be visible to players, 0 otherwise.
+
+
+GridSettings payload
+--------------------
+A new ``GridSettings`` message carries grid visibility and styling fields: square size, line width, softness, opacity, RGB color, and X/Y offsets (0-1 squares).

--- a/docs/source/protocol.rst
+++ b/docs/source/protocol.rst
@@ -44,6 +44,7 @@ messages are sent in this order:
 3. Map image
 4. Viewport
 5. Cursor
+6. Grid settings
 
 Message type IDs
 ----------------
@@ -75,6 +76,9 @@ Message type IDs
    * - 7
      - Cursor
      - Cursor position, appearance, and visibility.
+   * - 8
+     - Grid settings
+     - Grid visibility, dimensions, colour, opacity, and offsets.
 
 Session info payload
 --------------------
@@ -245,4 +249,39 @@ This payload controls the cursor shown to players.
 
 GridSettings payload
 --------------------
-A new ``GridSettings`` message carries grid visibility and styling fields: square size, line width, softness, opacity, RGB color, and X/Y offsets (0-1 squares).
+
+This payload controls the grid overlay shown to players.
+
+.. list-table:: Grid settings payload fields
+   :header-rows: 1
+
+   * - Field
+     - Size (bytes)
+     - Notes
+   * - Visible
+     - 1
+     - 1 if the grid should be shown, 0 otherwise.
+   * - Square size
+     - 8 (float64)
+     - The size of one grid square in map pixels.
+   * - Line width
+     - 8 (float64)
+     - The rendered grid line width in map pixels.
+   * - Opacity
+     - 8 (float64)
+     - The line opacity in the range 0-1.
+   * - Red channel
+     - 1
+     - The red channel of the grid colour.
+   * - Green channel
+     - 1
+     - The green channel of the grid colour.
+   * - Blue channel
+     - 1
+     - The blue channel of the grid colour.
+   * - Offset X
+     - 8 (float64)
+     - Horizontal offset in grid-square units, typically in the range 0-1.
+   * - Offset Y
+     - 8 (float64)
+     - Vertical offset in grid-square units, typically in the range 0-1.


### PR DESCRIPTION
### Motivation

- Provide a DM-facing grid overlay so the DM can configure grid visibility, square size, line width, line-edge softness, opacity, color, and X/Y offsets and have players render the same grid.
- Ensure the grid renders below the fog layer and above the map image and that settings are synchronized to connected players (including late joiners).

### Description

- Added a new tool `ToolType.Grid`, selection state (`IsGridSelected`) and command (`SelectGridCommand`) and DM viewmodel bindings to configure `IsGridVisible`, `GridSquareSize`, `GridLineWidth`, `GridLineSoftness`, `GridOpacity`, `GridColor`, `GridOffsetX`, and `GridOffsetY` in `DmViewModel` and the DM view UI.
- Implemented grid rendering in `MapCanvas` via new styled properties (`IsGridVisibleProperty`, `GridSquareSizeProperty`, `GridLineWidthProperty`, `GridLineSoftnessProperty`, `GridOpacityProperty`, `GridColorProperty`, `GridOffsetXProperty`, `GridOffsetYProperty`) and a `RenderGrid` helper that draws the grid after drawing the map image and before drawing the fog bitmap.
- Added protocol support with `GridSettingsPayload` and extended `MessageType` with `GridSettings`, plus host-side `SendGridSettingsAsync` and caching in `DmHostService` for late joiners and client-side `GridSettingsReceived` dispatch in `PlayerClientService`.
- Wired players to apply incoming settings in `PlayerViewModel` (`OnGridSettingsReceived`) and bound the player `MapCanvas` to the same grid properties, and added DM/Player view bindings and a placeholder icon button (`brick-wall.svg`) and a DM-side settings panel for the grid.
- Updated docs: `docs/source/protocol.rst` documents the `GridSettings` payload and `docs/source/changelog.rst` includes the new feature entry.

### Testing

- Attempted to build the solution with `dotnet build /workspace/dmap-net/dmap.slnx -v minimal`, but the command failed because `dotnet` is not available in this environment.
- Performed repository checks and a commit (`git commit -m "Add DM grid tool and synchronized grid settings payload"`) which succeeded, and inspected the modified files to verify wiring and bindings were added as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ed163fc808329ba4263b9715d014c)